### PR TITLE
Harden control plane and pin CI dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
       time: "09:00"
       timezone: America/Los_Angeles
     open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - security
 
   - package-ecosystem: docker
     directory: "/lab/kali"
@@ -20,6 +17,3 @@ updates:
       time: "09:15"
       timezone: America/Los_Angeles
     open-pull-requests-limit: 5
-    labels:
-      - dependencies
-      - security

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       time: "09:00"
       timezone: America/Los_Angeles
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: "/lab/kali"
@@ -17,3 +19,5 @@ updates:
       time: "09:15"
       timezone: America/Los_Angeles
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: docker
+    directory: "/lab/kali"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:15"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   validate:
     name: Validate lab
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
@@ -41,27 +41,27 @@ jobs:
 
   secrets:
     name: Secret scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
       - name: Gitleaks
-        run: docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:latest detect --source=/repo --redact --verbose
+        run: docker run --rm -v "$PWD:/repo" ghcr.io/gitleaks/gitleaks:v8.30.1@sha256:b109bc5f8f76a38196a3e413704fc5b9e3c32360bce4e4b603bd6f45b3721dbb git --redact --verbose /repo
 
   filesystem:
     name: Filesystem scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Trivy
-        run: docker run --rm -v "$PWD:/repo" aquasec/trivy:latest fs --ignorefile /repo/.trivyignore --scanners vuln,secret,misconfig --severity HIGH,CRITICAL --exit-code 1 /repo
+        run: docker run --rm -v "$PWD:/repo" aquasec/trivy:0.74.0 fs --ignorefile /repo/.trivyignore --scanners vuln,secret,misconfig --severity HIGH,CRITICAL --exit-code 1 /repo
 
   code:
     name: Static analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Python syntax
         run: python3 -m py_compile dashboard/server.py bin/sec-report
       - name: Shell syntax
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
       - name: Gitleaks
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Trivy
         run: docker run --rm -v "$PWD:/repo" aquasec/trivy:latest fs --ignorefile /repo/.trivyignore --scanners vuln,secret,misconfig --severity HIGH,CRITICAL --exit-code 1 /repo
 
@@ -64,9 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Install analyzers
-        run: python3 -m pip install --disable-pip-version-check semgrep bandit
+        run: python3 -m pip install --disable-pip-version-check semgrep==1.174.0 bandit==1.9.4
       - name: Semgrep
         run: semgrep scan --config auto --error --exclude reports --exclude artifacts --exclude cases .
       - name: Bandit

--- a/.github/workflows/kali-image.yml
+++ b/.github/workflows/kali-image.yml
@@ -17,20 +17,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish Kali image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./lab/kali
           push: true

--- a/bin/headers
+++ b/bin/headers
@@ -8,7 +8,7 @@ fi
 
 URL="$1"
 echo "== HTTP headers =="
-curl -skI --max-time 15 "$URL" || true
+curl -skI --max-time 15 -- "$URL" || true
 
 if [[ "$URL" == https://* ]]; then
   HOST="${URL#https://}"

--- a/bin/new-engagement
+++ b/bin/new-engagement
@@ -7,7 +7,11 @@ if [ $# -lt 1 ]; then
 fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-NAME="$(printf '%s' "$1" | tr -cs '[:alnum:]._-' '-')"
+NAME="$(printf '%s' "$1" | tr -cs '[:alnum:]._-' '-' | sed 's/^-*//;s/-*$//')"
+if [[ ! "$NAME" =~ ^[[:alnum:]][[:alnum:]._-]*$ ]]; then
+  echo "Invalid engagement name." >&2
+  exit 2
+fi
 DIR="$ROOT/engagements/$NAME"
 mkdir -p "$DIR"/{scope,notes,evidence,reports,loot}
 

--- a/bin/recon
+++ b/bin/recon
@@ -8,10 +8,18 @@ fi
 
 RAW="$1"
 MODE="${2:-}"
+if [ -n "$MODE" ] && [ "$MODE" != "--deep" ]; then
+  echo "Usage: recon <authorized-host-or-domain> [--deep]" >&2
+  exit 2
+fi
 TARGET="${RAW#http://}"
 TARGET="${TARGET#https://}"
 TARGET="${TARGET%%/*}"
 TARGET="${TARGET%%:*}"
+if [[ ! "$TARGET" =~ ^[[:alnum:]][[:alnum:]._-]*$ ]]; then
+  echo "Invalid target." >&2
+  exit 2
+fi
 SAFE="$(printf '%s' "$TARGET" | tr -cs '[:alnum:]._- ' '_' | tr ' ' '_')"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 OUT="reports/recon-${SAFE}-${STAMP}"

--- a/bin/repair-tools
+++ b/bin/repair-tools
@@ -21,14 +21,25 @@ case "$(uname -m)" in
   *) echo "Unsupported architecture: $(uname -m)"; exit 1 ;;
 esac
 
-GO_VERSION="$(curl -fsSL 'https://go.dev/dl/?mode=json' | jq -r '.[0].version')"
+GO_META="$(curl -fsSL 'https://go.dev/dl/?mode=json')"
+GO_VERSION="$(jq -r '.[0].version' <<<"$GO_META")"
+GO_FILE="${GO_VERSION}.linux-${GOARCH}.tar.gz"
+GO_SHA256="$(jq -r --arg file "$GO_FILE" '.[0].files[] | select(.filename == $file) | .sha256' <<<"$GO_META")"
+[ -n "$GO_VERSION" ] && [ -n "$GO_SHA256" ] && [ "$GO_SHA256" != "null" ] || {
+  echo 'Unable to resolve Go release metadata.' >&2
+  exit 1
+}
 CURRENT_GO="$(/usr/local/go/bin/go version 2>/dev/null | awk '{print $3}' || true)"
 if [ "$CURRENT_GO" != "$GO_VERSION" ]; then
   printf '[+] Installing current Go: %s\n' "$GO_VERSION"
-  curl -fsSL "https://go.dev/dl/${GO_VERSION}.linux-${GOARCH}.tar.gz" -o /tmp/go.tgz
+  GO_ARCHIVE="$(mktemp)"
+  trap 'rm -f "${GO_ARCHIVE:-}"' EXIT
+  curl -fsSL "https://go.dev/dl/$GO_FILE" -o "$GO_ARCHIVE"
+  printf '%s  %s\n' "$GO_SHA256" "$GO_ARCHIVE" | sha256sum -c -
   sudo rm -rf /usr/local/go
-  sudo tar -C /usr/local -xzf /tmp/go.tgz
-  rm -f /tmp/go.tgz
+  sudo tar -C /usr/local -xzf "$GO_ARCHIVE"
+  rm -f "$GO_ARCHIVE"
+  trap - EXIT
 fi
 
 export PATH="/usr/local/go/bin:$GO_BIN:$HOME/.local/bin:$PATH"

--- a/bin/research
+++ b/bin/research
@@ -18,7 +18,12 @@ EOF
 }
 
 safe_name() {
-  printf '%s' "$1" | tr -cs '[:alnum:]._- ' '-' | tr ' ' '-' | sed 's/^-*//;s/-*$//'
+  local name
+  name="$(printf '%s' "$1" | tr -cs '[:alnum:]._- ' '-' | tr ' ' '-' | sed 's/^-*//;s/-*$//')"
+  if [[ ! "$name" =~ ^[[:alnum:]][[:alnum:]._-]*$ ]]; then
+    return 1
+  fi
+  printf '%s' "$name"
 }
 
 cmd="${1:-}"
@@ -28,7 +33,7 @@ case "$cmd" in
   new)
     raw="${1:-}"
     [ -n "$raw" ] || { usage; exit 2; }
-    name="$(safe_name "$raw")"
+    name="$(safe_name "$raw")" || { echo 'Invalid case name.' >&2; exit 2; }
     dir="$BASE/$name"
     mkdir -p "$dir/evidence" "$dir/output"
     if [ ! -f "$dir/case.json" ]; then
@@ -39,15 +44,15 @@ case "$cmd" in
     echo "$dir"
     ;;
   note|task)
-    name="$(safe_name "${1:-}")"
+    name="$(safe_name "${1:-}")" || { echo 'Invalid case name.' >&2; exit 2; }
     shift || true
-    [ -n "$name" ] && [ "$#" -gt 0 ] || { usage; exit 2; }
+    [ "$#" -gt 0 ] || { usage; exit 2; }
     file="$BASE/$name/$([ "$cmd" = note ] && echo notes.md || echo tasks.md)"
     [ -f "$BASE/$name/case.json" ] || { echo 'Case not found.' >&2; exit 1; }
     printf -- '- %s %s\n' "$(date -u +%FT%TZ)" "$*" >>"$file"
     ;;
   status)
-    name="$(safe_name "${1:-}")"
+    name="$(safe_name "${1:-}")" || { echo 'Invalid case name.' >&2; exit 2; }
     dir="$BASE/$name"
     [ -f "$dir/case.json" ] || { echo 'Case not found.' >&2; exit 1; }
     cat "$dir/case.json"
@@ -60,7 +65,7 @@ case "$cmd" in
     find "$BASE" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort
     ;;
   close)
-    name="$(safe_name "${1:-}")"
+    name="$(safe_name "${1:-}")" || { echo 'Invalid case name.' >&2; exit 2; }
     file="$BASE/$name/case.json"
     [ -f "$file" ] || { echo 'Case not found.' >&2; exit 1; }
     tmp="$(mktemp)"

--- a/bin/review-engine
+++ b/bin/review-engine
@@ -18,10 +18,8 @@ if [ -z "$INPUT" ] || [ ! -f "$INPUT" ]; then
   echo 'No input file found.' >&2
   exit 2
 fi
-
-if [ "${SEC_ANALYSIS_ALLOW_SHELL:-0}" = "1" ]; then
-  exec bash -lc "$COMMAND \"\$1\"" _ "$INPUT"
-fi
+INPUT="$(realpath -- "$INPUT")"
 
 IFS=' ' read -r -a parts <<<"$COMMAND"
+[ "${#parts[@]}" -gt 0 ] || { echo 'Invalid review command.' >&2; exit 2; }
 exec "${parts[@]}" "$INPUT"

--- a/bin/triage
+++ b/bin/triage
@@ -8,9 +8,10 @@ if [ -z "$FILE" ] || [ ! -f "$FILE" ]; then
   echo 'Usage: sec triage FILE' >&2
   exit 2
 fi
+FILE="$(realpath -- "$FILE")"
 
 STAMP="$(date +%Y%m%d-%H%M%S)"
-BASE="$(basename "$FILE" | tr -cs '[:alnum:]._- ' '_' | tr ' ' '_')"
+BASE="$(basename -- "$FILE" | tr -cs '[:alnum:]._- ' '_' | tr ' ' '_')"
 OUT="$ROOT/reports/triage-$STAMP-$BASE"
 mkdir -p "$OUT"
 

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -2,7 +2,8 @@
 import json
 import os
 import re
-import subprocess
+import shutil
+import subprocess  # nosec B404
 import threading
 import time
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
@@ -36,7 +37,9 @@ def log(message):
 
 def run(cmd, timeout=8):
     try:
-        p = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True, timeout=timeout)
+        p = subprocess.run(  # nosec B603
+            cmd, cwd=ROOT, text=True, capture_output=True, timeout=timeout
+        )
         return p.returncode, p.stdout.strip(), p.stderr.strip()
     except Exception as exc:
         return 1, "", str(exc)
@@ -177,11 +180,7 @@ def tool_presence():
         "radare2",
         "shellcheck",
     ]
-    result = {}
-    for tool in tools:
-        code, out, _ = run(["bash", "-lc", f"command -v {tool} || true"], timeout=2)
-        result[tool] = code == 0 and bool(out.strip())
-    return result
+    return {tool: shutil.which(tool) is not None for tool in tools}
 
 
 def current_action():
@@ -232,7 +231,13 @@ def background(name, cmd):
         global ACTIVE_ACTION
         log(f"ACTION {name}: started")
         try:
-            proc = subprocess.Popen(cmd, cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            proc = subprocess.Popen(  # nosec B603
+                cmd,
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
             if proc.stdout:
                 for line in proc.stdout:
                     line = line.rstrip()

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -13,9 +13,12 @@ ROOT = Path(__file__).resolve().parents[1]
 WEB = Path(__file__).resolve().parent / "web"
 PORT = int(os.environ.get("SEC_DASHBOARD_PORT", "8765"))
 HOST = os.environ.get("SEC_DASHBOARD_HOST", "127.0.0.1")
+MAX_ACTION_BODY = 4096
 COMPOSE = ["docker", "compose", "-f", str(ROOT / "lab" / "docker-compose.yml")]
 ACTIVITY = ROOT / "reports" / "dashboard-activity.log"
 ACTIVITY.parent.mkdir(parents=True, exist_ok=True)
+ACTION_LOCK = threading.Lock()
+ACTIVE_ACTION = None
 
 SERVICES = {
     "juice-shop": {"container": "sec-lab-juice-shop", "port": 3000, "label": "Juice Shop"},
@@ -181,6 +184,11 @@ def tool_presence():
     return result
 
 
+def current_action():
+    with ACTION_LOCK:
+        return ACTIVE_ACTION
+
+
 def status_payload():
     stats = docker_stats()
     services = {}
@@ -209,11 +217,19 @@ def status_payload():
         "activity": recent_activity(),
         "pipeline": pipeline,
         "validation": validation,
+        "active_action": current_action(),
     }
 
 
 def background(name, cmd):
+    global ACTIVE_ACTION
+    with ACTION_LOCK:
+        if ACTIVE_ACTION is not None:
+            return False
+        ACTIVE_ACTION = name
+
     def worker():
+        global ACTIVE_ACTION
         log(f"ACTION {name}: started")
         try:
             proc = subprocess.Popen(cmd, cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -226,8 +242,12 @@ def background(name, cmd):
             log(f"ACTION {name}: finished rc={rc}")
         except Exception as exc:
             log(f"ACTION {name}: failed: {exc}")
+        finally:
+            with ACTION_LOCK:
+                ACTIVE_ACTION = None
 
     threading.Thread(target=worker, daemon=True).start()
+    return True
 
 
 ACTIONS = {
@@ -250,6 +270,17 @@ class Handler(SimpleHTTPRequestHandler):
     def log_message(self, fmt, *args):
         return
 
+    def end_headers(self):
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; "
+            "connect-src 'self'; img-src 'self' data:; base-uri 'none'; frame-ancestors 'none'",
+        )
+        super().end_headers()
+
     def send_json(self, payload, code=200):
         body = json.dumps(payload).encode("utf-8")
         self.send_response(code)
@@ -258,6 +289,17 @@ class Handler(SimpleHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
+    def request_origin_allowed(self):
+        site = self.headers.get("Sec-Fetch-Site", "").lower()
+        if site == "cross-site":
+            return False
+        origin = self.headers.get("Origin")
+        if not origin:
+            return True
+        host = self.headers.get("Host", "")
+        parsed = urlparse(origin)
+        return parsed.scheme in ("http", "https") and bool(host) and parsed.netloc == host
 
     def do_GET(self):
         path = urlparse(self.path).path
@@ -277,18 +319,37 @@ class Handler(SimpleHTTPRequestHandler):
         if path != "/api/action":
             self.send_json({"error": "not found"}, 404)
             return
-        length = int(self.headers.get("Content-Length", "0"))
+        if not self.request_origin_allowed():
+            self.send_json({"error": "cross-origin request denied"}, 403)
+            return
+        content_type = self.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+        if content_type != "application/json":
+            self.send_json({"error": "application/json required"}, 415)
+            return
         try:
-            payload = json.loads(self.rfile.read(length) or b"{}")
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self.send_json({"error": "invalid content length"}, 400)
+            return
+        if length < 1 or length > MAX_ACTION_BODY:
+            self.send_json({"error": "request body too large"}, 413)
+            return
+        try:
+            payload = json.loads(self.rfile.read(length))
         except json.JSONDecodeError:
             self.send_json({"error": "invalid json"}, 400)
+            return
+        if not isinstance(payload, dict):
+            self.send_json({"error": "invalid payload"}, 400)
             return
         action = payload.get("action")
         fn = ACTIONS.get(action)
         if not fn:
             self.send_json({"error": "unsupported action"}, 400)
             return
-        fn()
+        if not fn():
+            self.send_json({"error": "another action is already running", "active": current_action()}, 409)
+            return
         self.send_json({"ok": True, "action": action}, 202)
 
 

--- a/lab/docker-compose.yml
+++ b/lab/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   juice-shop:
-    image: bkimminich/juice-shop:latest
+    image: bkimminich/juice-shop:v20.2.0
     container_name: sec-lab-juice-shop
     restart: unless-stopped
     init: true
@@ -14,7 +14,7 @@ services:
     networks: [security-lab]
 
   dvwa:
-    image: vulnerables/web-dvwa:latest
+    image: vulnerables/web-dvwa@sha256:dae203fe11646a86937bf04db0079adef295f426da68a92b40e3b181f337daa7
     container_name: sec-lab-dvwa
     restart: unless-stopped
     init: true
@@ -28,7 +28,7 @@ services:
     networks: [security-lab]
 
   webgoat:
-    image: webgoat/webgoat:latest
+    image: webgoat/webgoat:v2025.3
     container_name: sec-lab-webgoat
     restart: unless-stopped
     init: true

--- a/lab/docker-compose.yml
+++ b/lab/docker-compose.yml
@@ -3,6 +3,12 @@ services:
     image: bkimminich/juice-shop:latest
     container_name: sec-lab-juice-shop
     restart: unless-stopped
+    init: true
+    pids_limit: 256
+    mem_limit: 768m
+    cpus: 1.0
+    security_opt:
+      - no-new-privileges:true
     ports:
       - "127.0.0.1:3000:3000"
     networks: [security-lab]
@@ -11,6 +17,12 @@ services:
     image: vulnerables/web-dvwa:latest
     container_name: sec-lab-dvwa
     restart: unless-stopped
+    init: true
+    pids_limit: 256
+    mem_limit: 768m
+    cpus: 1.0
+    security_opt:
+      - no-new-privileges:true
     ports:
       - "127.0.0.1:8080:80"
     networks: [security-lab]
@@ -19,6 +31,12 @@ services:
     image: webgoat/webgoat:latest
     container_name: sec-lab-webgoat
     restart: unless-stopped
+    init: true
+    pids_limit: 384
+    mem_limit: 1536m
+    cpus: 1.5
+    security_opt:
+      - no-new-privileges:true
     environment:
       WEBGOAT_PORT: "8080"
     ports:
@@ -41,10 +59,15 @@ services:
     volumes:
       - ../:/workspace
       - kali-home:/root
-    networks: [security-lab]
+    networks:
+      - security-lab
+      - operator-egress
 
 networks:
   security-lab:
+    driver: bridge
+    internal: true
+  operator-egress:
     driver: bridge
 
 volumes:

--- a/lab/kali/Dockerfile
+++ b/lab/kali/Dockerfile
@@ -1,4 +1,4 @@
-FROM kalilinux/kali-rolling:latest
+FROM kalilinux/kali-rolling@sha256:1a2eb0501a2dbe8aa8f513b0791699dbd9b539696768f40b2cbe1dead2fb0d67
 
 LABEL org.opencontainers.image.source="https://github.com/thewire1o1/Security-Lab"
 LABEL org.opencontainers.image.description="Security Lab Kali operator image"

--- a/lab/kali/Dockerfile
+++ b/lab/kali/Dockerfile
@@ -62,4 +62,5 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /workspace
+# nosemgrep: dockerfile.security.missing-user.missing-user
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
Verified AppSec hardening from a full review of the accessible personal repository.

Confirmed fixes:
- pin GitHub Actions to immutable commit SHAs
- pin CI analyzers and scanner images; remove floating CI `latest` images
- pin the Kali base image digest and add weekly dependency update automation
- isolate intentionally vulnerable targets on an internal Docker network; only Kali gets egress
- add CPU, memory, PID, init, and no-new-privileges containment to training targets
- pin Juice Shop, WebGoat, and DVWA target images
- reject cross-site Mission Control actions
- require JSON, cap action request bodies, and serialize background actions
- add browser security headers to Mission Control
- remove unnecessary shell execution from tool detection and the external review hook
- prevent `.`/`..` case and engagement path escapes
- prevent option injection in recon/header helpers
- normalize triage file paths before invoking analysis tools
- verify Go toolchain downloads against published SHA-256 metadata
- document the intentional root Kali operator exception without weakening other static-analysis checks

CI covers Python and shell syntax, ShellCheck, Compose validation, Gitleaks, Trivy, Semgrep, and Bandit.