### PR TITLE
Platform v2: general development control plane

### DIFF
--- a/bin/dpsr
+++ b/bin/dpsr
@@ -2,4 +2,50 @@
 set -Eeuo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-exec "$ROOT/bin/sec" "$@"
+cmd="${1:-help}"
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+usage() {
+  cat <<'EOF'
+DPSR Platform
+
+Development platform:
+  dpsr platform              show platform status
+  dpsr profile list          list available development/security profiles
+  dpsr profile show NAME     inspect one profile
+  dpsr project list          list registered projects
+  dpsr project init NAME --profile PROFILE
+                             create and register a managed project
+  dpsr project register PATH register an existing dpsr.toml project
+  dpsr project show NAME     inspect a registered project
+  dpsr project verify NAME   run its lint/test/build verification pipeline
+  dpsr job list              show persisted jobs
+  dpsr job show ID           show one job
+  dpsr job run PROJECT CMD   execute one manifest command as a tracked job
+  dpsr runner list           show local and external runner types
+
+Security/research compatibility commands remain available unchanged:
+  dpsr doctor | up | down | ps | scan | dashboard | gui | mcp | report
+  dpsr defend | review | validate | fuzz | triage | research | engine
+  dpsr kali-build | kali | clean | disk | update | new
+
+The legacy `sec` entry point remains available for security workflows.
+EOF
+}
+
+case "$cmd" in
+  help|-h|--help)
+    usage
+    ;;
+  platform)
+    exec python3 -m security_lab.platform.cli status "$@"
+    ;;
+  profile|project|job|runner)
+    exec python3 -m security_lab.platform.cli "$cmd" "$@"
+    ;;
+  *)
+    exec "$ROOT/bin/sec" "$cmd" "$@"
+    ;;
+esac

--- a/docs/PLATFORM-V2.md
+++ b/docs/PLATFORM-V2.md
@@ -1,0 +1,93 @@
+# DPSR Platform v2
+
+## Purpose
+
+DPSR Platform v2 expands the existing security-research environment into a general development and automation control plane. The security lab remains intact as a first-class profile rather than being replaced.
+
+## Branch strategy
+
+`master` remains the stable control-plane branch. Platform work is developed and validated on `platform-v2` and merged only after CI and runtime checks pass. The legacy `sec` command remains available for compatibility.
+
+## Control surfaces
+
+- `dpsr` is the umbrella platform CLI.
+- `sec` remains the security/research compatibility CLI.
+- MCP remains the structured automation surface.
+- The GitHub recovery bridge remains separate from MCP.
+- The external lifecycle controller remains outside the Codespace.
+
+## Project model
+
+A managed project contains a `dpsr.toml` manifest. The manifest declares:
+
+- project identity and profile
+- runner type
+- named commands with argv, working directory, and timeout
+- service ports
+
+Project registry and job state are stored outside the controller repository. In Codespaces the defaults are:
+
+- projects: `/workspaces/dpsr-projects`
+- platform state: `/workspaces/.dpsr/platform`
+
+Both paths can be overridden with `DPSR_PROJECTS_ROOT` and `DPSR_PLATFORM_STATE`.
+
+## Profiles
+
+The initial built-in profile catalog includes:
+
+- `security`
+- `fullstack-web`
+- `nextjs`
+- `fastapi`
+- `flutter`
+- `react-native`
+- `android`
+- `ios`
+
+Profiles are data files under `platform/profiles/`. They define stack metadata, capabilities, default runner, commands, ports, and scaffold layout.
+
+## Runners
+
+Phase 1 provides executable local and Docker runners. The runner boundary executes pre-tokenized argv vectors without invoking a shell and prevents command working directories from escaping the project root.
+
+External runner identities are reserved for GitHub Actions and Codespaces. Native iOS is intentionally classified as an external/macOS workload rather than pretending the Linux Codespace can build it locally.
+
+## Jobs
+
+Commands execute as persisted jobs with explicit lifecycle state:
+
+`queued -> running -> succeeded|failed`
+
+Each job records project, command, timestamps, return code, and bounded stdout/stderr. Job state persists independently from a terminal session.
+
+## CLI
+
+```text
+dpsr platform
+dpsr profile list
+dpsr profile show NAME
+dpsr project init NAME --profile PROFILE
+dpsr project register PATH
+dpsr project list
+dpsr project show NAME
+dpsr project verify NAME
+dpsr job run PROJECT COMMAND
+dpsr job list
+dpsr job show ID
+dpsr runner list
+```
+
+Existing security commands continue to work through `dpsr` and `sec` unchanged.
+
+## Next implementation layers
+
+1. Framework-native bootstrap providers for Next.js, FastAPI, Flutter, React Native, Android, and full-stack compositions.
+2. GitHub Actions and Codespaces runner backends with queued asynchronous job execution.
+3. Platform-aware dashboard pages for projects, jobs, previews, deployments, and logs.
+4. Structured MCP tools for project discovery, job submission, job status, and artifact retrieval.
+5. Shared service management for databases, package caches, preview URLs, build artifacts, deployments, and environment configuration.
+6. Deployment providers and release pipelines.
+7. Central metrics, logs, health history, notifications, and automated recovery policies.
+
+The architecture deliberately keeps these layers above the existing supervisor, recovery bridge, MCP server, and external lifecycle controller so the hardened management plane does not need to be redesigned.

--- a/dpsr.toml
+++ b/dpsr.toml
@@ -1,0 +1,27 @@
+# DPSR project manifest
+[project]
+name = "security-lab"
+profile = "security"
+category = "security"
+
+[runner]
+type = "local"
+
+[services]
+dashboard = 8765
+mcp = 8766
+
+[commands.lint]
+argv = ["python3", "-m", "compileall", "-q", "security_lab"]
+cwd = "."
+timeout = 120
+
+[commands.test]
+argv = ["python3", "-m", "unittest", "discover", "-s", "tests", "-v"]
+cwd = "."
+timeout = 600
+
+[commands.doctor]
+argv = ["bin/dpsr", "doctor"]
+cwd = "."
+timeout = 120

--- a/platform/profiles/android.json
+++ b/platform/profiles/android.json
@@ -1,0 +1,18 @@
+{
+  "profile": {
+    "name": "android",
+    "title": "Native Android",
+    "category": "mobile",
+    "description": "Native Android application profile for Gradle builds, lint, tests, emulator/device workflows, CI, and release automation.",
+    "runner": "local",
+    "stack": ["kotlin", "android", "gradle"],
+    "capabilities": ["android", "testing", "emulator", "ci", "release"],
+    "scaffold": "android"
+  },
+  "commands": {
+    "lint": {"argv": ["./gradlew", "lint"], "cwd": "app", "timeout": 1800},
+    "test": {"argv": ["./gradlew", "test"], "cwd": "app", "timeout": 2400},
+    "build": {"argv": ["./gradlew", "assembleDebug"], "cwd": "app", "timeout": 3600}
+  },
+  "services": {}
+}

--- a/platform/profiles/fastapi.json
+++ b/platform/profiles/fastapi.json
@@ -1,0 +1,18 @@
+{
+  "profile": {
+    "name": "fastapi",
+    "title": "FastAPI Service",
+    "category": "api",
+    "description": "Python API service profile with tests, static validation, development server, containers, and deployment hooks.",
+    "runner": "local",
+    "stack": ["python", "fastapi", "pytest"],
+    "capabilities": ["api", "testing", "containers", "ci", "deploy"],
+    "scaffold": "fastapi"
+  },
+  "commands": {
+    "lint": {"argv": ["python3", "-m", "compileall", "-q", "src"], "cwd": ".", "timeout": 120},
+    "test": {"argv": ["python3", "-m", "pytest", "-q"], "cwd": ".", "timeout": 900},
+    "dev": {"argv": ["python3", "-m", "uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"], "cwd": "src", "timeout": 86400}
+  },
+  "services": {"api": 8000}
+}

--- a/platform/profiles/flutter.json
+++ b/platform/profiles/flutter.json
@@ -1,0 +1,18 @@
+{
+  "profile": {
+    "name": "flutter",
+    "title": "Flutter Mobile",
+    "category": "mobile",
+    "description": "Cross-platform Flutter application profile for Android, iOS, web, testing, and CI automation.",
+    "runner": "local",
+    "stack": ["dart", "flutter"],
+    "capabilities": ["android", "ios", "web", "testing", "ci", "release"],
+    "scaffold": "flutter"
+  },
+  "commands": {
+    "lint": {"argv": ["flutter", "analyze"], "cwd": "app", "timeout": 900},
+    "test": {"argv": ["flutter", "test"], "cwd": "app", "timeout": 1200},
+    "build": {"argv": ["flutter", "build", "apk"], "cwd": "app", "timeout": 3600}
+  },
+  "services": {}
+}

--- a/platform/profiles/fullstack-web.json
+++ b/platform/profiles/fullstack-web.json
@@ -1,0 +1,18 @@
+{
+  "profile": {
+    "name": "fullstack-web",
+    "title": "Full-Stack Web",
+    "category": "web",
+    "description": "Multi-service web application profile for frontend, API, shared packages, database, containers, CI, previews, and deployment automation.",
+    "runner": "local",
+    "stack": ["nextjs", "fastapi", "postgresql", "docker"],
+    "capabilities": ["frontend", "api", "database", "containers", "preview", "ci", "deploy"],
+    "scaffold": "fullstack-web"
+  },
+  "commands": {
+    "build": {"argv": ["docker", "compose", "build"], "cwd": ".", "timeout": 1800},
+    "dev": {"argv": ["docker", "compose", "up"], "cwd": ".", "timeout": 86400},
+    "down": {"argv": ["docker", "compose", "down"], "cwd": ".", "timeout": 120}
+  },
+  "services": {"web": 3000, "api": 8000, "postgres": 5432}
+}

--- a/platform/profiles/ios.json
+++ b/platform/profiles/ios.json
@@ -1,0 +1,17 @@
+{
+  "profile": {
+    "name": "ios",
+    "title": "Native iOS",
+    "category": "mobile",
+    "description": "Native iOS application profile for Xcode builds, tests, simulator workflows, CI, signing, and release automation on macOS runners.",
+    "runner": "github-actions",
+    "stack": ["swift", "ios", "xcode"],
+    "capabilities": ["ios", "testing", "simulator", "ci", "signing", "release"],
+    "scaffold": "ios"
+  },
+  "commands": {
+    "test": {"argv": ["xcodebuild", "test"], "cwd": "app", "timeout": 3600},
+    "build": {"argv": ["xcodebuild", "build"], "cwd": "app", "timeout": 3600}
+  },
+  "services": {}
+}

--- a/platform/profiles/nextjs.json
+++ b/platform/profiles/nextjs.json
@@ -1,0 +1,19 @@
+{
+  "profile": {
+    "name": "nextjs",
+    "title": "Next.js Web App",
+    "category": "web",
+    "description": "Modern TypeScript web application profile with lint, test, build, development, preview, and deployment hooks.",
+    "runner": "local",
+    "stack": ["node", "typescript", "nextjs"],
+    "capabilities": ["frontend", "server-rendering", "api-routes", "preview", "ci", "deploy"],
+    "scaffold": "nextjs"
+  },
+  "commands": {
+    "lint": {"argv": ["npm", "run", "lint"], "cwd": ".", "timeout": 600},
+    "test": {"argv": ["npm", "test"], "cwd": ".", "timeout": 900},
+    "build": {"argv": ["npm", "run", "build"], "cwd": ".", "timeout": 1800},
+    "dev": {"argv": ["npm", "run", "dev"], "cwd": ".", "timeout": 86400}
+  },
+  "services": {"web": 3000}
+}

--- a/platform/profiles/react-native.json
+++ b/platform/profiles/react-native.json
@@ -1,0 +1,18 @@
+{
+  "profile": {
+    "name": "react-native",
+    "title": "React Native Mobile",
+    "category": "mobile",
+    "description": "React Native application profile for Android, iOS, JavaScript/TypeScript testing, and CI automation.",
+    "runner": "local",
+    "stack": ["node", "typescript", "react-native"],
+    "capabilities": ["android", "ios", "testing", "ci", "release"],
+    "scaffold": "react-native"
+  },
+  "commands": {
+    "lint": {"argv": ["npm", "run", "lint"], "cwd": "app", "timeout": 900},
+    "test": {"argv": ["npm", "test"], "cwd": "app", "timeout": 1200},
+    "android": {"argv": ["npm", "run", "android"], "cwd": "app", "timeout": 3600}
+  },
+  "services": {"metro": 8081}
+}

--- a/platform/profiles/security.json
+++ b/platform/profiles/security.json
@@ -1,0 +1,18 @@
+{
+  "profile": {
+    "name": "security",
+    "title": "Security Research",
+    "category": "security",
+    "description": "DPSR isolated security research, training, defensive validation, fuzzing, triage, and operator tooling.",
+    "runner": "local",
+    "stack": ["python", "docker", "kali", "mcp"],
+    "capabilities": ["pentest-lab", "defensive-analysis", "fuzzing", "triage", "research"],
+    "scaffold": "security"
+  },
+  "commands": {
+    "lint": {"argv": ["python3", "-m", "compileall", "-q", "security_lab"], "cwd": ".", "timeout": 120},
+    "test": {"argv": ["python3", "-m", "unittest", "discover", "-s", "tests", "-v"], "cwd": ".", "timeout": 600},
+    "doctor": {"argv": ["bin/dpsr", "doctor"], "cwd": ".", "timeout": 120}
+  },
+  "services": {"dashboard": 8765, "mcp": 8766}
+}

--- a/security_lab/platform/__init__.py
+++ b/security_lab/platform/__init__.py
@@ -1,0 +1,5 @@
+"""DPSR general-purpose development platform."""
+
+from .models import CommandSpec, Profile, Project
+
+__all__ = ["CommandSpec", "Profile", "Project"]

--- a/security_lab/platform/cli.py
+++ b/security_lab/platform/cli.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from security_lab.common import ROOT
+
+from .jobs import get_job, list_jobs, run_job
+from .profiles import get_profile, load_profiles
+from .registry import get_project, list_projects, register_project, unregister_project
+from .runners import RUNNERS
+from .scaffold import init_project
+
+
+def _project_row(project) -> dict[str, object]:
+    return {
+        "name": project.name,
+        "profile": project.profile,
+        "runner": project.runner,
+        "path": str(project.path),
+        "commands": sorted(project.commands),
+        "services": project.services,
+    }
+
+
+def cmd_status(_args: argparse.Namespace) -> int:
+    profiles = load_profiles()
+    projects = list_projects()
+    payload = {
+        "platform": "dpsr-v2",
+        "root": str(ROOT),
+        "profiles": len(profiles),
+        "projects": len(projects),
+        "runners": sorted(RUNNERS),
+        "jobs": len(list_jobs(500)),
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_profile(args: argparse.Namespace) -> int:
+    profiles = load_profiles()
+    if args.profile_command == "list":
+        for profile in profiles.values():
+            stack = ", ".join(profile.stack)
+            print(f"{profile.name}\t{profile.category}\t{profile.runner}\t{stack}")
+        return 0
+    profile = get_profile(args.name)
+    print(json.dumps({
+        "name": profile.name,
+        "title": profile.title,
+        "category": profile.category,
+        "description": profile.description,
+        "runner": profile.runner,
+        "stack": profile.stack,
+        "capabilities": profile.capabilities,
+        "commands": sorted(profile.commands),
+        "services": profile.services,
+        "scaffold": profile.scaffold,
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_project(args: argparse.Namespace) -> int:
+    action = args.project_command
+    if action == "list":
+        print(json.dumps([_project_row(row) for row in list_projects()], indent=2, sort_keys=True))
+        return 0
+    if action == "show":
+        print(json.dumps(_project_row(get_project(args.name)), indent=2, sort_keys=True))
+        return 0
+    if action == "register":
+        project = register_project(Path(args.path))
+        print(json.dumps(_project_row(project), indent=2, sort_keys=True))
+        return 0
+    if action == "remove":
+        if not unregister_project(args.name):
+            raise ValueError(f"Unknown project: {args.name}")
+        print(f"Removed project registry entry: {args.name}")
+        return 0
+    if action == "init":
+        target = Path(args.path).expanduser() if args.path else None
+        project = init_project(args.name, args.profile, target)
+        print(json.dumps(_project_row(project), indent=2, sort_keys=True))
+        return 0
+    if action == "verify":
+        project = get_project(args.name)
+        selected = [name for name in ("lint", "test", "build") if name in project.commands]
+        if not selected:
+            raise ValueError(f"Project '{args.name}' defines none of lint, test, or build.")
+        failed = False
+        for name in selected:
+            job = run_job(args.name, name)
+            print(f"{job['id']}\t{name}\t{job['state']}")
+            failed = failed or job["state"] != "succeeded"
+        return 1 if failed else 0
+    raise ValueError(f"Unsupported project action: {action}")
+
+
+def cmd_job(args: argparse.Namespace) -> int:
+    if args.job_command == "list":
+        print(json.dumps(list_jobs(args.limit), indent=2, sort_keys=True))
+        return 0
+    if args.job_command == "show":
+        print(json.dumps(get_job(args.id), indent=2, sort_keys=True))
+        return 0
+    job = run_job(args.project, args.command)
+    print(json.dumps(job, indent=2, sort_keys=True))
+    return 0 if job["state"] == "succeeded" else 1
+
+
+def cmd_runner(args: argparse.Namespace) -> int:
+    if args.runner_command == "list":
+        for name in sorted(RUNNERS):
+            print(name)
+        print("github-actions\texternal")
+        print("codespace\texternal")
+        return 0
+    raise ValueError(f"Unsupported runner action: {args.runner_command}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="DPSR development platform control plane")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("status")
+
+    profile = sub.add_parser("profile")
+    profile_sub = profile.add_subparsers(dest="profile_command", required=True)
+    profile_sub.add_parser("list")
+    profile_show = profile_sub.add_parser("show")
+    profile_show.add_argument("name")
+
+    project = sub.add_parser("project")
+    project_sub = project.add_subparsers(dest="project_command", required=True)
+    project_sub.add_parser("list")
+    project_show = project_sub.add_parser("show")
+    project_show.add_argument("name")
+    project_register = project_sub.add_parser("register")
+    project_register.add_argument("path")
+    project_remove = project_sub.add_parser("remove")
+    project_remove.add_argument("name")
+    project_init = project_sub.add_parser("init")
+    project_init.add_argument("name")
+    project_init.add_argument("--profile", required=True)
+    project_init.add_argument("--path")
+    project_verify = project_sub.add_parser("verify")
+    project_verify.add_argument("name")
+
+    job = sub.add_parser("job")
+    job_sub = job.add_subparsers(dest="job_command", required=True)
+    job_list = job_sub.add_parser("list")
+    job_list.add_argument("--limit", type=int, default=50)
+    job_show = job_sub.add_parser("show")
+    job_show.add_argument("id")
+    job_run = job_sub.add_parser("run")
+    job_run.add_argument("project")
+    job_run.add_argument("command")
+
+    runner = sub.add_parser("runner")
+    runner_sub = runner.add_subparsers(dest="runner_command", required=True)
+    runner_sub.add_parser("list")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        if args.command == "status":
+            return cmd_status(args)
+        if args.command == "profile":
+            return cmd_profile(args)
+        if args.command == "project":
+            return cmd_project(args)
+        if args.command == "job":
+            return cmd_job(args)
+        if args.command == "runner":
+            return cmd_runner(args)
+        return 2
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"dpsr: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/security_lab/platform/jobs.py
+++ b/security_lab/platform/jobs.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
 
 import json
-import os
 import secrets
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from security_lab.common import ROOT
-
+from .paths import STATE_ROOT
 from .registry import get_project
 from .runners import get_runner
 
-STATE_ROOT = Path(os.environ.get("DPSR_PLATFORM_STATE", str(ROOT / ".dpsr" / "platform"))).expanduser()
 JOBS_ROOT = STATE_ROOT / "jobs"
 VALID_STATES = {"queued", "running", "succeeded", "failed"}
 

--- a/security_lab/platform/jobs.py
+++ b/security_lab/platform/jobs.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from security_lab.common import ROOT
+
+from .registry import get_project
+from .runners import get_runner
+
+STATE_ROOT = Path(os.environ.get("DPSR_PLATFORM_STATE", str(ROOT / ".dpsr" / "platform"))).expanduser()
+JOBS_ROOT = STATE_ROOT / "jobs"
+VALID_STATES = {"queued", "running", "succeeded", "failed"}
+
+
+def _utc() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _job_path(job_id: str) -> Path:
+    if not job_id or any(ch not in "abcdefghijklmnopqrstuvwxyz0123456789-" for ch in job_id.lower()):
+        raise ValueError("Invalid job id.")
+    return JOBS_ROOT / f"{job_id}.json"
+
+
+def _write(job: dict[str, Any]) -> None:
+    JOBS_ROOT.mkdir(parents=True, exist_ok=True)
+    path = _job_path(str(job["id"]))
+    temp = path.with_suffix(".tmp")
+    temp.write_text(json.dumps(job, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temp.replace(path)
+
+
+def create_job(project: str, command: str) -> dict[str, Any]:
+    job = {
+        "id": f"job-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{secrets.token_hex(3)}",
+        "project": project,
+        "command": command,
+        "state": "queued",
+        "created_at": _utc(),
+        "started_at": None,
+        "finished_at": None,
+        "returncode": None,
+        "stdout": "",
+        "stderr": "",
+    }
+    _write(job)
+    return job
+
+
+def get_job(job_id: str) -> dict[str, Any]:
+    path = _job_path(job_id)
+    if not path.exists():
+        raise ValueError(f"Unknown job: {job_id}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def list_jobs(limit: int = 50) -> list[dict[str, Any]]:
+    if not JOBS_ROOT.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for path in sorted(JOBS_ROOT.glob("job-*.json"), reverse=True)[: max(1, min(limit, 500))]:
+        try:
+            rows.append(json.loads(path.read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError):
+            continue
+    return rows
+
+
+def run_job(project_name: str, command_name: str) -> dict[str, Any]:
+    project = get_project(project_name)
+    try:
+        command = project.commands[command_name]
+    except KeyError as exc:
+        available = ", ".join(sorted(project.commands)) or "none"
+        raise ValueError(f"Project '{project_name}' has no command '{command_name}'. Available: {available}") from exc
+
+    job = create_job(project_name, command_name)
+    job["state"] = "running"
+    job["started_at"] = _utc()
+    _write(job)
+
+    try:
+        result = get_runner(project.runner).run(project, command)
+        job["returncode"] = result.returncode
+        job["stdout"] = result.stdout[-200_000:]
+        job["stderr"] = result.stderr[-200_000:]
+        job["state"] = "succeeded" if result.ok else "failed"
+    except Exception as exc:
+        job["returncode"] = 1
+        job["stderr"] = str(exc)
+        job["state"] = "failed"
+    job["finished_at"] = _utc()
+    _write(job)
+    return job

--- a/security_lab/platform/models.py
+++ b/security_lab/platform/models.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import shlex
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    argv: tuple[str, ...]
+    cwd: str = "."
+    timeout: int = 900
+
+    @classmethod
+    def from_value(cls, value: Any) -> "CommandSpec":
+        if isinstance(value, str):
+            return cls(tuple(shlex.split(value)))
+        if isinstance(value, list) and all(isinstance(item, str) for item in value):
+            return cls(tuple(value))
+        if isinstance(value, dict):
+            raw_argv = value.get("argv", [])
+            if isinstance(raw_argv, str):
+                argv = tuple(shlex.split(raw_argv))
+            elif isinstance(raw_argv, list) and all(isinstance(item, str) for item in raw_argv):
+                argv = tuple(raw_argv)
+            else:
+                raise ValueError("Command argv must be a string or list of strings.")
+            cwd = str(value.get("cwd", "."))
+            timeout = int(value.get("timeout", 900))
+            if timeout < 1 or timeout > 86400:
+                raise ValueError("Command timeout must be between 1 and 86400 seconds.")
+            return cls(argv=argv, cwd=cwd, timeout=timeout)
+        raise ValueError("Unsupported command definition.")
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    title: str
+    category: str
+    description: str
+    runner: str
+    stack: tuple[str, ...] = ()
+    capabilities: tuple[str, ...] = ()
+    commands: dict[str, CommandSpec] = field(default_factory=dict)
+    services: dict[str, int] = field(default_factory=dict)
+    scaffold: str = "generic"
+
+
+@dataclass(frozen=True)
+class Project:
+    name: str
+    path: Path
+    profile: str
+    runner: str
+    commands: dict[str, CommandSpec]
+    services: dict[str, int]
+    metadata: dict[str, Any]
+
+
+def load_project_manifest(path: Path) -> Project:
+    manifest_path = path / "dpsr.toml"
+    with manifest_path.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    project = data.get("project") or {}
+    runner = data.get("runner") or {}
+    raw_commands = data.get("commands") or {}
+    services = data.get("services") or {}
+
+    name = str(project.get("name", "")).strip()
+    profile = str(project.get("profile", "generic")).strip() or "generic"
+    runner_type = str(runner.get("type", "local")).strip() or "local"
+    if not name:
+        raise ValueError(f"Project manifest at {manifest_path} has no project.name.")
+
+    commands = {key: CommandSpec.from_value(value) for key, value in raw_commands.items()}
+    normalized_services: dict[str, int] = {}
+    for key, value in services.items():
+        port = int(value)
+        if port < 1 or port > 65535:
+            raise ValueError(f"Invalid service port for {key}: {port}")
+        normalized_services[str(key)] = port
+
+    return Project(
+        name=name,
+        path=path.resolve(),
+        profile=profile,
+        runner=runner_type,
+        commands=commands,
+        services=normalized_services,
+        metadata={"project": project, "runner": runner},
+    )

--- a/security_lab/platform/paths.py
+++ b/security_lab/platform/paths.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+WORKSPACES = Path("/workspaces")
+PERSISTENT_ROOT = WORKSPACES if WORKSPACES.is_dir() else Path.home()
+STATE_ROOT = Path(
+    os.environ.get("DPSR_PLATFORM_STATE", str(PERSISTENT_ROOT / ".dpsr" / "platform"))
+).expanduser()
+PROJECTS_ROOT = Path(
+    os.environ.get("DPSR_PROJECTS_ROOT", str(PERSISTENT_ROOT / "dpsr-projects"))
+).expanduser()

--- a/security_lab/platform/profiles.py
+++ b/security_lab/platform/profiles.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from security_lab.common import ROOT
+
+from .models import CommandSpec, Profile
+
+PROFILE_ROOT = ROOT / "platform" / "profiles"
+
+
+def _profile_from_dict(data: dict[str, Any]) -> Profile:
+    meta = data.get("profile") or {}
+    name = str(meta.get("name", "")).strip()
+    if not name:
+        raise ValueError("Profile is missing profile.name.")
+    commands = {
+        str(key): CommandSpec.from_value(value)
+        for key, value in (data.get("commands") or {}).items()
+    }
+    services: dict[str, int] = {}
+    for key, value in (data.get("services") or {}).items():
+        services[str(key)] = int(value)
+    return Profile(
+        name=name,
+        title=str(meta.get("title", name)),
+        category=str(meta.get("category", "development")),
+        description=str(meta.get("description", "")),
+        runner=str(meta.get("runner", "local")),
+        stack=tuple(str(item) for item in meta.get("stack", [])),
+        capabilities=tuple(str(item) for item in meta.get("capabilities", [])),
+        commands=commands,
+        services=services,
+        scaffold=str(meta.get("scaffold", "generic")),
+    )
+
+
+def load_profiles(root: Path = PROFILE_ROOT) -> dict[str, Profile]:
+    profiles: dict[str, Profile] = {}
+    if not root.exists():
+        return profiles
+    for path in sorted(root.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        profile = _profile_from_dict(data)
+        if profile.name in profiles:
+            raise ValueError(f"Duplicate profile name: {profile.name}")
+        profiles[profile.name] = profile
+    return profiles
+
+
+def get_profile(name: str) -> Profile:
+    profiles = load_profiles()
+    try:
+        return profiles[name]
+    except KeyError as exc:
+        available = ", ".join(sorted(profiles)) or "none"
+        raise ValueError(f"Unknown profile '{name}'. Available: {available}") from exc

--- a/security_lab/platform/registry.py
+++ b/security_lab/platform/registry.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any
 
-from security_lab.common import ROOT
-
 from .models import Project, load_project_manifest
+from .paths import STATE_ROOT
 
-STATE_ROOT = Path(os.environ.get("DPSR_PLATFORM_STATE", str(ROOT / ".dpsr" / "platform"))).expanduser()
 REGISTRY_PATH = STATE_ROOT / "projects.json"
 
 
@@ -54,7 +51,7 @@ def unregister_project(name: str) -> bool:
 def list_projects() -> list[Project]:
     data = _load_raw()
     rows: list[Project] = []
-    for name, entry in sorted(data["projects"].items()):
+    for _name, entry in sorted(data["projects"].items()):
         try:
             path = Path(str(entry["path"]))
             rows.append(load_project_manifest(path))

--- a/security_lab/platform/registry.py
+++ b/security_lab/platform/registry.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from security_lab.common import ROOT
+
+from .models import Project, load_project_manifest
+
+STATE_ROOT = Path(os.environ.get("DPSR_PLATFORM_STATE", str(ROOT / ".dpsr" / "platform"))).expanduser()
+REGISTRY_PATH = STATE_ROOT / "projects.json"
+
+
+def _load_raw() -> dict[str, Any]:
+    if not REGISTRY_PATH.exists():
+        return {"version": 1, "projects": {}}
+    data = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Platform registry is invalid.")
+    data.setdefault("version", 1)
+    data.setdefault("projects", {})
+    return data
+
+
+def _write_raw(data: dict[str, Any]) -> None:
+    STATE_ROOT.mkdir(parents=True, exist_ok=True)
+    temp = REGISTRY_PATH.with_suffix(".tmp")
+    temp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temp.replace(REGISTRY_PATH)
+
+
+def register_project(path: Path) -> Project:
+    project = load_project_manifest(path.resolve())
+    data = _load_raw()
+    projects = data["projects"]
+    projects[project.name] = {
+        "path": str(project.path),
+        "profile": project.profile,
+    }
+    _write_raw(data)
+    return project
+
+
+def unregister_project(name: str) -> bool:
+    data = _load_raw()
+    removed = data["projects"].pop(name, None) is not None
+    if removed:
+        _write_raw(data)
+    return removed
+
+
+def list_projects() -> list[Project]:
+    data = _load_raw()
+    rows: list[Project] = []
+    for name, entry in sorted(data["projects"].items()):
+        try:
+            path = Path(str(entry["path"]))
+            rows.append(load_project_manifest(path))
+        except (KeyError, OSError, ValueError, json.JSONDecodeError):
+            continue
+    return rows
+
+
+def get_project(name: str) -> Project:
+    data = _load_raw()
+    try:
+        entry = data["projects"][name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown project: {name}") from exc
+    return load_project_manifest(Path(str(entry["path"])))

--- a/security_lab/platform/runners.py
+++ b/security_lab/platform/runners.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from .models import CommandSpec, Project
+
+
+@dataclass(frozen=True)
+class RunResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+class Runner:
+    name = "base"
+
+    def run(self, project: Project, command: CommandSpec) -> RunResult:
+        raise NotImplementedError
+
+    @staticmethod
+    def _cwd(project: Project, relative: str) -> Path:
+        target = (project.path / relative).resolve()
+        try:
+            target.relative_to(project.path)
+        except ValueError as exc:
+            raise ValueError("Command cwd escapes project root.") from exc
+        if not target.is_dir():
+            raise ValueError(f"Command cwd does not exist: {relative}")
+        return target
+
+
+class LocalRunner(Runner):
+    name = "local"
+
+    def run(self, project: Project, command: CommandSpec) -> RunResult:
+        if not command.argv:
+            raise ValueError("Command argv is empty.")
+        result = subprocess.run(
+            list(command.argv),
+            cwd=self._cwd(project, command.cwd),
+            env=os.environ.copy(),
+            text=True,
+            capture_output=True,
+            timeout=command.timeout,
+            check=False,
+        )
+        return RunResult(result.returncode, result.stdout, result.stderr)
+
+
+class DockerRunner(Runner):
+    name = "docker"
+
+    def run(self, project: Project, command: CommandSpec) -> RunResult:
+        runner = project.metadata.get("runner") or {}
+        image = str(runner.get("image", "")).strip()
+        if not image:
+            raise ValueError("Docker runner requires runner.image in dpsr.toml.")
+        if not command.argv:
+            raise ValueError("Command argv is empty.")
+
+        workdir = Path("/workspace") / command.cwd
+        argv = [
+            "docker",
+            "run",
+            "--rm",
+            "--init",
+            "-v",
+            f"{project.path}:/workspace",
+            "-w",
+            str(workdir),
+            image,
+            *command.argv,
+        ]
+        result = subprocess.run(
+            argv,
+            cwd=project.path,
+            env=os.environ.copy(),
+            text=True,
+            capture_output=True,
+            timeout=command.timeout,
+            check=False,
+        )
+        return RunResult(result.returncode, result.stdout, result.stderr)
+
+
+RUNNERS: Mapping[str, type[Runner]] = {
+    LocalRunner.name: LocalRunner,
+    DockerRunner.name: DockerRunner,
+}
+
+
+def get_runner(name: str) -> Runner:
+    try:
+        return RUNNERS[name]()
+    except KeyError as exc:
+        available = ", ".join(sorted(RUNNERS))
+        raise ValueError(f"Runner '{name}' is not locally executable. Available: {available}") from exc

--- a/security_lab/platform/runners.py
+++ b/security_lab/platform/runners.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-import subprocess
+import subprocess  # nosec B404
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
@@ -44,7 +44,7 @@ class LocalRunner(Runner):
     def run(self, project: Project, command: CommandSpec) -> RunResult:
         if not command.argv:
             raise ValueError("Command argv is empty.")
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             list(command.argv),
             cwd=self._cwd(project, command.cwd),
             env=os.environ.copy(),
@@ -80,7 +80,7 @@ class DockerRunner(Runner):
             image,
             *command.argv,
         ]
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603
             argv,
             cwd=project.path,
             env=os.environ.copy(),

--- a/security_lab/platform/scaffold.py
+++ b/security_lab/platform/scaffold.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from security_lab.common import ROOT
+
+from .models import CommandSpec, Profile
+from .profiles import get_profile
+from .registry import register_project
+
+PROJECT_NAME = re.compile(r"^[a-z0-9][a-z0-9._-]{1,62}$")
+
+
+def _toml_string(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _render_command(name: str, spec: CommandSpec) -> str:
+    argv = ", ".join(_toml_string(item) for item in spec.argv)
+    return (
+        f"[commands.{name}]\n"
+        f"argv = [{argv}]\n"
+        f"cwd = {_toml_string(spec.cwd)}\n"
+        f"timeout = {spec.timeout}\n"
+    )
+
+
+def render_manifest(name: str, profile: Profile) -> str:
+    lines = [
+        "# DPSR project manifest",
+        "[project]",
+        f"name = {_toml_string(name)}",
+        f"profile = {_toml_string(profile.name)}",
+        f"category = {_toml_string(profile.category)}",
+        "",
+        "[runner]",
+        f"type = {_toml_string(profile.runner)}",
+        "",
+    ]
+    if profile.services:
+        lines.append("[services]")
+        for service, port in sorted(profile.services.items()):
+            lines.append(f"{service} = {port}")
+        lines.append("")
+    for command_name, command in sorted(profile.commands.items()):
+        lines.append(_render_command(command_name, command).rstrip())
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _seed_layout(target: Path, profile: Profile) -> None:
+    scaffold = profile.scaffold
+    if scaffold == "fullstack-web":
+        for relative in ("apps/web", "apps/api", "packages/shared", "infra"):
+            (target / relative).mkdir(parents=True, exist_ok=True)
+    elif scaffold in {"nextjs", "fastapi"}:
+        (target / "src").mkdir(parents=True, exist_ok=True)
+    elif scaffold in {"flutter", "react-native", "android", "ios"}:
+        (target / "app").mkdir(parents=True, exist_ok=True)
+    else:
+        (target / "src").mkdir(parents=True, exist_ok=True)
+
+
+def init_project(name: str, profile_name: str, target: Path | None = None):
+    normalized = name.strip().lower()
+    if not PROJECT_NAME.fullmatch(normalized):
+        raise ValueError("Project name must be 2-63 lowercase letters, digits, dots, underscores, or hyphens.")
+    profile = get_profile(profile_name)
+    destination = (target or (ROOT / "projects" / normalized)).resolve()
+    if destination.exists() and any(destination.iterdir()):
+        raise ValueError(f"Project directory is not empty: {destination}")
+    destination.mkdir(parents=True, exist_ok=True)
+    _seed_layout(destination, profile)
+    (destination / "dpsr.toml").write_text(render_manifest(normalized, profile), encoding="utf-8")
+    (destination / "README.md").write_text(
+        f"# {normalized}\n\nDPSR profile: `{profile.name}`\n\n{profile.description}\n",
+        encoding="utf-8",
+    )
+    return register_project(destination)

--- a/security_lab/platform/scaffold.py
+++ b/security_lab/platform/scaffold.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from security_lab.common import ROOT
-
 from .models import CommandSpec, Profile
+from .paths import PROJECTS_ROOT
 from .profiles import get_profile
 from .registry import register_project
 
@@ -68,7 +67,7 @@ def init_project(name: str, profile_name: str, target: Path | None = None):
     if not PROJECT_NAME.fullmatch(normalized):
         raise ValueError("Project name must be 2-63 lowercase letters, digits, dots, underscores, or hyphens.")
     profile = get_profile(profile_name)
-    destination = (target or (ROOT / "projects" / normalized)).resolve()
+    destination = (target or (PROJECTS_ROOT / normalized)).resolve()
     if destination.exists() and any(destination.iterdir()):
         raise ValueError(f"Project directory is not empty: {destination}")
     destination.mkdir(parents=True, exist_ok=True)

--- a/security_lab/remote_agent_ext.py
+++ b/security_lab/remote_agent_ext.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
-import subprocess
+import subprocess  # nosec B404
 import sys
 from pathlib import Path
 from typing import Any
@@ -52,9 +52,9 @@ class BridgeGitHubClient(base.GitHubClient):
     def _read_dedicated_token(cls) -> str:
         target = cls._token_file()
         try:
-            token = target.read_text(encoding="utf-8").strip()
+            token: str | None = target.read_text(encoding="utf-8").strip()
         except OSError:
-            token = ""
+            token = None
         if token:
             return token
 
@@ -154,7 +154,7 @@ class RemoteAgent(base.RemoteAgent):
         self.client.resolve_token()
         self.config.reports.mkdir(parents=True, exist_ok=True)
         with self.config.logfile.open("a", encoding="utf-8") as log:
-            process = subprocess.Popen(
+            process = subprocess.Popen(  # nosec B603
                 [sys.executable, "-m", "security_lab.remote_agent_ext", "run"],
                 cwd=self.config.root,
                 stdin=subprocess.DEVNULL,

--- a/security_lab/remote_agent_ext.py
+++ b/security_lab/remote_agent_ext.py
@@ -68,7 +68,7 @@ class BridgeGitHubClient(base.GitHubClient):
             return ""
 
         target.parent.mkdir(parents=True, exist_ok=True)
-        os.chmod(target.parent, 0o700)
+        os.chmod(target.parent, 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
         target.write_text(legacy + "\n", encoding="utf-8")
         os.chmod(target, 0o600)
         return legacy

--- a/tests/test_platform_core.py
+++ b/tests/test_platform_core.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from security_lab.platform import jobs, registry
+from security_lab.platform.models import CommandSpec, load_project_manifest
+from security_lab.platform.profiles import load_profiles
+from security_lab.platform.runners import get_runner
+
+
+class PlatformCoreTests(unittest.TestCase):
+    def test_builtin_profiles_cover_core_domains(self) -> None:
+        profiles = load_profiles()
+        expected = {
+            "security",
+            "fullstack-web",
+            "nextjs",
+            "fastapi",
+            "flutter",
+            "react-native",
+            "android",
+            "ios",
+        }
+        self.assertTrue(expected.issubset(profiles))
+        self.assertEqual(profiles["ios"].runner, "github-actions")
+
+    def test_manifest_rejects_cwd_escape_at_runner_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "dpsr.toml").write_text(
+                """
+[project]
+name = "demo"
+profile = "fastapi"
+[runner]
+type = "local"
+[commands.bad]
+argv = ["python3", "-c", "print('x')"]
+cwd = "../"
+""".strip() + "\n",
+                encoding="utf-8",
+            )
+            project = load_project_manifest(root)
+            with self.assertRaises(ValueError):
+                get_runner("local").run(project, project.commands["bad"])
+
+    def test_registry_and_local_job_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            base = Path(temp)
+            project_root = base / "project"
+            state = base / "state"
+            project_root.mkdir()
+            (project_root / "dpsr.toml").write_text(
+                """
+[project]
+name = "demo"
+profile = "generic"
+[runner]
+type = "local"
+[commands.test]
+argv = ["python3", "-c", "print('platform-ok')"]
+cwd = "."
+timeout = 30
+""".strip() + "\n",
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(registry, "STATE_ROOT", state),
+                mock.patch.object(registry, "REGISTRY_PATH", state / "projects.json"),
+                mock.patch.object(jobs, "STATE_ROOT", state),
+                mock.patch.object(jobs, "JOBS_ROOT", state / "jobs"),
+            ):
+                registered = registry.register_project(project_root)
+                self.assertEqual(registered.name, "demo")
+                result = jobs.run_job("demo", "test")
+                self.assertEqual(result["state"], "succeeded")
+                self.assertIn("platform-ok", result["stdout"])
+                self.assertEqual(jobs.get_job(result["id"])["returncode"], 0)
+
+    def test_command_string_is_tokenized_without_shell(self) -> None:
+        command = CommandSpec.from_value("python3 -c 'print(123)'")
+        self.assertEqual(command.argv[0], "python3")
+        self.assertNotIn("shell", command.argv)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Expands DPSR from a security-focused Codespace into a general project/job platform while preserving the hardened security stack and `sec` compatibility surface.

Initial platform layer includes:
- `dpsr` umbrella CLI
- data-driven project profiles
- `dpsr.toml` manifests
- persistent project registry and job state outside the control repo
- local and Docker runner backends
- explicit queued/running/succeeded/failed job lifecycle
- project init/register/show/list/verify commands
- job run/list/show commands
- profiles for security, full-stack web, Next.js, FastAPI, Flutter, React Native, Android, and iOS
- platform core tests and architecture documentation

`master` remains stable; this PR is intended to let existing CI validate the new layer before any merge or live control-plane migration.