### PR TITLE
Platform v2: fix tracked job CLI dispatch

### DIFF
--- a/security_lab/platform/cli.py
+++ b/security_lab/platform/cli.py
@@ -105,7 +105,7 @@ def cmd_job(args: argparse.Namespace) -> int:
     if args.job_command == "show":
         print(json.dumps(get_job(args.id), indent=2, sort_keys=True))
         return 0
-    job = run_job(args.project, args.command)
+    job = run_job(args.project, args.command_name)
     print(json.dumps(job, indent=2, sort_keys=True))
     return 0 if job["state"] == "succeeded" else 1
 
@@ -155,7 +155,7 @@ def build_parser() -> argparse.ArgumentParser:
     job_show.add_argument("id")
     job_run = job_sub.add_parser("run")
     job_run.add_argument("project")
-    job_run.add_argument("command")
+    job_run.add_argument("command_name")
 
     runner = sub.add_parser("runner")
     runner_sub = runner.add_subparsers(dest="runner_command", required=True)

--- a/tests/test_platform_core.py
+++ b/tests/test_platform_core.py
@@ -5,7 +5,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from security_lab.platform import jobs, registry
+from security_lab.platform import cli, jobs, registry
 from security_lab.platform.models import CommandSpec, load_project_manifest
 from security_lab.platform.profiles import load_profiles
 from security_lab.platform.runners import get_runner
@@ -80,6 +80,13 @@ timeout = 30
                 self.assertEqual(result["state"], "succeeded")
                 self.assertIn("platform-ok", result["stdout"])
                 self.assertEqual(jobs.get_job(result["id"])["returncode"], 0)
+
+    def test_job_run_parser_preserves_top_level_subcommand(self) -> None:
+        args = cli.build_parser().parse_args(["job", "run", "demo", "lint"])
+        self.assertEqual(args.command, "job")
+        self.assertEqual(args.job_command, "run")
+        self.assertEqual(args.project, "demo")
+        self.assertEqual(args.command_name, "lint")
 
     def test_command_string_is_tokenized_without_shell(self) -> None:
         command = CommandSpec.from_value("python3 -c 'print(123)'")


### PR DESCRIPTION
Fixes the runtime-only argparse collision found by the first live tracked job. The job command name now uses a distinct `command_name` destination so the top-level `job` subcommand is preserved. Adds a regression test that parses `job run demo lint` and verifies both dispatch fields.