### PR TITLE
Platform v2: structured MCP project and job tools

### DIFF
--- a/security_lab/mcp_probe.py
+++ b/security_lab/mcp_probe.py
@@ -21,6 +21,7 @@ async def probe() -> int:
             tools = await client.list_tools()
             names = sorted(tool.name for tool in tools.tools)
             health = await client.call_tool("health", {})
+            platform = await client.call_tool("platform_status", {"job_limit": 5})
             repo_status = await client.call_tool("repo_status", {})
             command = await client.call_tool(
                 "run_project_command",
@@ -37,8 +38,14 @@ async def probe() -> int:
 
             read_content = read_result.structured_content or {}
             content = read_content.get("content", "") if isinstance(read_content, dict) else ""
+            platform_content = platform.structured_content or {}
             checks = {
                 "health": not health.is_error,
+                "platform": (
+                    not platform.is_error
+                    and isinstance(platform_content, dict)
+                    and platform_content.get("platform") == "dpsr-v2"
+                ),
                 "repo_status": not repo_status.is_error,
                 "project_command": not command.is_error,
                 "repo_write": not write_result.is_error,

--- a/security_lab/mcp_server.py
+++ b/security_lab/mcp_server.py
@@ -10,6 +10,7 @@ from mcp.server import MCPServer
 from mcp.server.transport_security import TransportSecuritySettings
 
 from security_lab.common import ROOT, run_command, utc_timestamp
+from security_lab.platform import api as platform_api
 from security_lab.remote_agent import Config, GitHubClient
 from security_lab.remote_agent_ext import TaskRunner
 
@@ -26,8 +27,9 @@ SENSITIVE_SUFFIXES = (".key", ".pem", ".p12", ".pfx", ".kdbx")
 mcp = MCPServer(
     "Digital Paragon Security Research",
     instructions=(
-        "Control and inspect the DPSR Codespace. Prefer structured tools over shell-like operations. "
-        "The legacy GitHub remote-command bridge is intentionally independent and remains available as fallback."
+        "Control the DPSR development and security platform. Prefer structured project, job, repository, "
+        "and service tools over generic command execution. The GitHub recovery bridge remains an independent "
+        "fallback control path."
     ),
 )
 
@@ -78,6 +80,42 @@ def health() -> dict[str, Any]:
         "git_head": head.get("stdout", "").strip(),
         "utc": utc_timestamp(),
     }
+
+
+@mcp.tool()
+def platform_status(job_limit: int = 20) -> dict[str, Any]:
+    """Return DPSR platform profiles, registered projects, runner inventory, and recent jobs."""
+    return platform_api.snapshot(max(1, min(job_limit, 100)))
+
+
+@mcp.tool()
+def platform_profile(name: str) -> dict[str, Any]:
+    """Return one development or security profile by name."""
+    return platform_api.profile(name)
+
+
+@mcp.tool()
+def platform_project(name: str) -> dict[str, Any]:
+    """Return one registered DPSR project by name."""
+    return platform_api.project(name)
+
+
+@mcp.tool()
+def platform_project_init(name: str, profile_name: str) -> dict[str, Any]:
+    """Create and register a project in the managed DPSR project workspace using a built-in profile."""
+    return platform_api.create_project(name, profile_name)
+
+
+@mcp.tool()
+def platform_job(job_id: str) -> dict[str, Any]:
+    """Return one persisted DPSR job by id."""
+    return platform_api.job(job_id)
+
+
+@mcp.tool()
+def platform_job_run(project_name: str, command_name: str) -> dict[str, Any]:
+    """Execute one bounded manifest command as a persisted DPSR job."""
+    return platform_api.execute_job(project_name, command_name)
 
 
 @mcp.tool()

--- a/security_lab/platform/api.py
+++ b/security_lab/platform/api.py
@@ -10,6 +10,7 @@ from .runners import RUNNERS
 from .scaffold import init_project
 
 EXTERNAL_RUNNERS = ("codespace", "github-actions")
+MAX_STRUCTURED_JOB_TIMEOUT = 3600
 
 
 def profile_row(profile: Profile) -> dict[str, Any]:
@@ -84,6 +85,18 @@ def create_project(name: str, profile_name: str) -> dict[str, Any]:
 
 
 def execute_job(project_name: str, command_name: str) -> dict[str, Any]:
+    project_model = get_project(project_name)
+    try:
+        command = project_model.commands[command_name]
+    except KeyError as exc:
+        available = ", ".join(sorted(project_model.commands)) or "none"
+        raise ValueError(
+            f"Project '{project_name}' has no command '{command_name}'. Available: {available}"
+        ) from exc
+    if command.timeout > MAX_STRUCTURED_JOB_TIMEOUT:
+        raise ValueError(
+            f"Command '{command_name}' is long-running ({command.timeout}s) and is not eligible for synchronous MCP execution."
+        )
     return run_job(project_name, command_name)
 
 

--- a/security_lab/platform/api.py
+++ b/security_lab/platform/api.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .jobs import get_job, list_jobs, run_job
+from .models import Profile, Project
+from .profiles import get_profile, load_profiles
+from .registry import get_project, list_projects
+from .runners import RUNNERS
+from .scaffold import init_project
+
+EXTERNAL_RUNNERS = ("codespace", "github-actions")
+
+
+def profile_row(profile: Profile) -> dict[str, Any]:
+    return {
+        "name": profile.name,
+        "title": profile.title,
+        "category": profile.category,
+        "description": profile.description,
+        "runner": profile.runner,
+        "stack": list(profile.stack),
+        "capabilities": list(profile.capabilities),
+        "commands": sorted(profile.commands),
+        "services": profile.services,
+        "scaffold": profile.scaffold,
+    }
+
+
+def project_row(project: Project) -> dict[str, Any]:
+    return {
+        "name": project.name,
+        "path": str(project.path),
+        "profile": project.profile,
+        "runner": project.runner,
+        "commands": sorted(project.commands),
+        "services": project.services,
+    }
+
+
+def profiles() -> list[dict[str, Any]]:
+    return [profile_row(profile) for profile in load_profiles().values()]
+
+
+def projects() -> list[dict[str, Any]]:
+    return [project_row(project) for project in list_projects()]
+
+
+def jobs(limit: int = 50) -> list[dict[str, Any]]:
+    return list_jobs(max(1, min(limit, 500)))
+
+
+def snapshot(job_limit: int = 20) -> dict[str, Any]:
+    profile_rows = profiles()
+    project_rows = projects()
+    job_rows = jobs(job_limit)
+    return {
+        "platform": "dpsr-v2",
+        "profiles": profile_rows,
+        "projects": project_rows,
+        "jobs": job_rows,
+        "counts": {
+            "profiles": len(profile_rows),
+            "projects": len(project_rows),
+            "jobs": len(list_jobs(500)),
+        },
+        "runners": {
+            "local": sorted(RUNNERS),
+            "external": list(EXTERNAL_RUNNERS),
+        },
+    }
+
+
+def profile(name: str) -> dict[str, Any]:
+    return profile_row(get_profile(name))
+
+
+def project(name: str) -> dict[str, Any]:
+    return project_row(get_project(name))
+
+
+def create_project(name: str, profile_name: str) -> dict[str, Any]:
+    return project_row(init_project(name, profile_name))
+
+
+def execute_job(project_name: str, command_name: str) -> dict[str, Any]:
+    return run_job(project_name, command_name)
+
+
+def job(job_id: str) -> dict[str, Any]:
+    return get_job(job_id)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -12,14 +12,29 @@ class MCPServerTests(unittest.IsolatedAsyncioTestCase):
         async with Client(mcp) as client:
             tools = await client.list_tools()
             names = {tool.name for tool in tools.tools}
-            self.assertIn("health", names)
-            self.assertIn("run_task", names)
-            self.assertIn("repo_read", names)
-            self.assertIn("repo_write", names)
-            self.assertIn("run_project_command", names)
-            result = await client.call_tool("health", {})
-            self.assertFalse(result.is_error)
-            self.assertIsNotNone(result.structured_content)
+            expected = {
+                "health",
+                "run_task",
+                "repo_read",
+                "repo_write",
+                "run_project_command",
+                "platform_status",
+                "platform_profile",
+                "platform_project",
+                "platform_project_init",
+                "platform_job",
+                "platform_job_run",
+            }
+            self.assertTrue(expected.issubset(names))
+
+            health = await client.call_tool("health", {})
+            self.assertFalse(health.is_error)
+            self.assertIsNotNone(health.structured_content)
+
+            platform = await client.call_tool("platform_status", {"job_limit": 5})
+            self.assertFalse(platform.is_error)
+            self.assertIsInstance(platform.structured_content, dict)
+            self.assertEqual(platform.structured_content.get("platform"), "dpsr-v2")
 
 
 if __name__ == "__main__":

--- a/tests/test_platform_core.py
+++ b/tests/test_platform_core.py
@@ -5,8 +5,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from security_lab.platform import cli, jobs, registry
-from security_lab.platform.models import CommandSpec, load_project_manifest
+from security_lab.platform import api, cli, jobs, registry
+from security_lab.platform.models import CommandSpec, Project, load_project_manifest
 from security_lab.platform.profiles import load_profiles
 from security_lab.platform.runners import get_runner
 
@@ -87,6 +87,20 @@ timeout = 30
         self.assertEqual(args.job_command, "run")
         self.assertEqual(args.project, "demo")
         self.assertEqual(args.command_name, "lint")
+
+    def test_structured_job_rejects_long_running_command(self) -> None:
+        project = Project(
+            name="demo",
+            path=Path("/tmp/demo"),
+            profile="generic",
+            runner="local",
+            commands={"dev": CommandSpec(("python3",), timeout=86400)},
+            services={},
+            metadata={},
+        )
+        with mock.patch.object(api, "get_project", return_value=project):
+            with self.assertRaisesRegex(ValueError, "not eligible for synchronous MCP execution"):
+                api.execute_job("demo", "dev")
 
     def test_command_string_is_tokenized_without_shell(self) -> None:
         command = CommandSpec.from_value("python3 -c 'print(123)'")


### PR DESCRIPTION
Adds a shared platform API and first-class MCP tools for DPSR v2 project/job automation.

Includes:
- platform status/profile/project tools
- managed project creation by built-in profile
- persisted job lookup and bounded tracked job execution
- synchronous MCP timeout boundary that rejects long-running dev/service commands
- MCP production probe coverage for platform status
- unit discovery and timeout-boundary tests

The existing recovery bridge remains separate and the generic command path remains available as fallback.