### PR TITLE
MCP lifecycle: recover validated orphan listeners

### DIFF
--- a/bin/mcp-control
+++ b/bin/mcp-control
@@ -15,12 +15,17 @@ read_pid() {
   fi
 }
 
-is_running() {
-  local pid
-  pid="$(read_pid)"
+is_mcp_pid() {
+  local pid="${1:-}"
   [ -n "$pid" ] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
   tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | grep -q 'security_lab.mcp_server'
+}
+
+is_running() {
+  local pid
+  pid="$(read_pid)"
+  is_mcp_pid "$pid"
 }
 
 port_open() {
@@ -49,6 +54,51 @@ log_tail() {
   fi
 }
 
+listener_pids() {
+  if command -v fuser >/dev/null 2>&1; then
+    fuser -n tcp "$PORT" 2>/dev/null | tr ' ' '\n' | grep -E '^[0-9]+$' || true
+    return 0
+  fi
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -t -iTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true
+    return 0
+  fi
+  return 0
+}
+
+stop_pid() {
+  local pid="$1"
+  kill "$pid" 2>/dev/null || true
+  for _ in $(seq 1 30); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  kill -9 "$pid" 2>/dev/null || true
+}
+
+stop_orphan_mcp_listeners() {
+  local found=0
+  local pid
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    found=1
+    if ! is_mcp_pid "$pid"; then
+      printf 'Port %s is owned by non-MCP process pid=%s; refusing to terminate it.\n' "$PORT" "$pid" >&2
+      return 1
+    fi
+    printf 'Stopping orphaned MCP listener: pid=%s port=%s\n' "$pid" "$PORT"
+    stop_pid "$pid"
+  done < <(listener_pids)
+
+  if [ "$found" -eq 1 ] && port_open; then
+    printf 'Port %s is still occupied after MCP cleanup.\n' "$PORT" >&2
+    return 1
+  fi
+  return 0
+}
+
 install_sdk() {
   if [ ! -x "$PYTHON" ]; then
     python3 -m venv "$VENV"
@@ -68,6 +118,12 @@ start_server() {
   fi
   if is_running; then
     stop_process
+  fi
+  if port_open; then
+    stop_orphan_mcp_listeners || {
+      log_tail
+      return 1
+    }
   fi
   install_sdk
   rm -f "$PIDFILE"
@@ -100,22 +156,15 @@ start_server() {
 }
 
 stop_process() {
-  if ! is_running; then
-    rm -f "$PIDFILE"
-    return 0
-  fi
   local pid
   pid="$(read_pid)"
-  kill "$pid" 2>/dev/null || true
-  for _ in $(seq 1 30); do
-    if ! kill -0 "$pid" 2>/dev/null; then
-      rm -f "$PIDFILE"
-      return 0
-    fi
-    sleep 0.1
-  done
-  kill -9 "$pid" 2>/dev/null || true
+  if is_mcp_pid "$pid"; then
+    stop_pid "$pid"
+  fi
   rm -f "$PIDFILE"
+  if port_open; then
+    stop_orphan_mcp_listeners
+  fi
 }
 
 stop_server() {


### PR DESCRIPTION
Fixes the live MCP restart loop caused by an orphaned MCP process retaining port 8766 after the PID file became stale.

The control script now:
- discovers listeners on the MCP port using fuser/lsof when available
- verifies a listener's cmdline contains `security_lab.mcp_server` before terminating it
- refuses to terminate unrelated processes
- cleans validated orphan listeners before starting a replacement
- applies the same cleanup on stop/restart

This preserves the existing bounded crash-log diagnostics.