### PR TITLE
Platform v2: real Next.js and FastAPI provisioning

### DIFF
--- a/platform/PROVISIONING.md
+++ b/platform/PROVISIONING.md
@@ -1,0 +1,17 @@
+# DPSR framework provisioning
+
+DPSR project initialization is responsible for creating a usable framework project, adding `dpsr.toml`, and registering the project in persistent platform state.
+
+## Next.js
+
+The `nextjs` profile provisions with the official `create-next-app` CLI using explicit noninteractive options for TypeScript, ESLint, Tailwind CSS, App Router, `src/`, Turbopack, npm, and disabled nested Git initialization. Node.js 20.9 or newer is required.
+
+Verification runs the profile's bounded `lint` and `build` jobs. Development and production server commands are intentionally long-running and are not eligible for synchronous MCP job execution.
+
+## FastAPI
+
+The `fastapi` profile creates an isolated `.venv`, installs project-local dependencies, writes a health endpoint and a pytest health check, and registers bounded `lint` and `test` jobs. Its development server is intentionally long-running and is not eligible for synchronous MCP job execution.
+
+## Failure behavior
+
+New projects created under the managed DPSR project root are removed when provisioning fails, allowing a clean retry. Custom external paths are never recursively deleted by the provisioner.

--- a/platform/profiles/fastapi.json
+++ b/platform/profiles/fastapi.json
@@ -3,16 +3,16 @@
     "name": "fastapi",
     "title": "FastAPI Service",
     "category": "api",
-    "description": "Python API service profile with tests, static validation, development server, containers, and deployment hooks.",
+    "description": "Python API service profile with isolated virtualenv provisioning, health endpoint, tests, static validation, development server, containers, CI, and deployment hooks.",
     "runner": "local",
-    "stack": ["python", "fastapi", "pytest"],
-    "capabilities": ["api", "testing", "containers", "ci", "deploy"],
+    "stack": ["python", "fastapi", "uvicorn", "pytest"],
+    "capabilities": ["api", "testing", "health", "containers", "ci", "deploy"],
     "scaffold": "fastapi"
   },
   "commands": {
-    "lint": {"argv": ["python3", "-m", "compileall", "-q", "src"], "cwd": ".", "timeout": 120},
-    "test": {"argv": ["python3", "-m", "pytest", "-q"], "cwd": ".", "timeout": 900},
-    "dev": {"argv": ["python3", "-m", "uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"], "cwd": "src", "timeout": 86400}
+    "lint": {"argv": [".venv/bin/python", "-m", "compileall", "-q", "src", "tests"], "cwd": ".", "timeout": 120},
+    "test": {"argv": [".venv/bin/python", "-m", "pytest", "-q"], "cwd": ".", "timeout": 900},
+    "dev": {"argv": ["../.venv/bin/python", "-m", "uvicorn", "main:app", "--reload", "--host", "0.0.0.0", "--port", "8000"], "cwd": "src", "timeout": 86400}
   },
   "services": {"api": 8000}
 }

--- a/platform/profiles/nextjs.json
+++ b/platform/profiles/nextjs.json
@@ -3,17 +3,17 @@
     "name": "nextjs",
     "title": "Next.js Web App",
     "category": "web",
-    "description": "Modern TypeScript web application profile with lint, test, build, development, preview, and deployment hooks.",
+    "description": "Modern TypeScript web application profile with automated provisioning, linting, production builds, development, preview, CI, and deployment hooks.",
     "runner": "local",
-    "stack": ["node", "typescript", "nextjs"],
+    "stack": ["node", "typescript", "nextjs", "react", "tailwind"],
     "capabilities": ["frontend", "server-rendering", "api-routes", "preview", "ci", "deploy"],
     "scaffold": "nextjs"
   },
   "commands": {
     "lint": {"argv": ["npm", "run", "lint"], "cwd": ".", "timeout": 600},
-    "test": {"argv": ["npm", "test"], "cwd": ".", "timeout": 900},
     "build": {"argv": ["npm", "run", "build"], "cwd": ".", "timeout": 1800},
-    "dev": {"argv": ["npm", "run", "dev"], "cwd": ".", "timeout": 86400}
+    "dev": {"argv": ["npm", "run", "dev", "--", "--hostname", "0.0.0.0", "--port", "3000"], "cwd": ".", "timeout": 86400},
+    "start": {"argv": ["npm", "run", "start", "--", "--hostname", "0.0.0.0", "--port", "3000"], "cwd": ".", "timeout": 86400}
   },
   "services": {"web": 3000}
 }

--- a/security_lab/platform/scaffold.py
+++ b/security_lab/platform/scaffold.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import re
+import shutil
 from pathlib import Path
+
+from security_lab.common import run_command
 
 from .models import CommandSpec, Profile
 from .paths import PROJECTS_ROOT
@@ -9,6 +12,8 @@ from .profiles import get_profile
 from .registry import register_project
 
 PROJECT_NAME = re.compile(r"^[a-z0-9][a-z0-9._-]{1,62}$")
+NODE_VERSION = re.compile(r"^v?(\d+)\.(\d+)(?:\.(\d+))?")
+MINIMUM_NEXT_NODE = (20, 9)
 
 
 def _toml_string(value: str) -> str:
@@ -49,6 +54,119 @@ def render_manifest(name: str, profile: Profile) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+def _command_failure(label: str, result: dict[str, object]) -> ValueError:
+    stderr = str(result.get("stderr") or "").strip()
+    stdout = str(result.get("stdout") or "").strip()
+    detail = stderr or stdout or "no process output"
+    return ValueError(f"{label} failed with exit code {result.get('returncode')}: {detail}")
+
+
+def _node_version() -> tuple[int, int, int]:
+    result = run_command(("node", "--version"), timeout=10)
+    if result["returncode"] != 0:
+        raise _command_failure("Node.js prerequisite check", result)
+    match = NODE_VERSION.match(str(result["stdout"]).strip())
+    if not match:
+        raise ValueError(f"Unable to parse Node.js version: {result['stdout']!r}")
+    major, minor, patch = match.groups()
+    return int(major), int(minor), int(patch or 0)
+
+
+def _ensure_next_prerequisites() -> None:
+    version = _node_version()
+    if version[:2] < MINIMUM_NEXT_NODE:
+        actual = ".".join(str(part) for part in version)
+        raise ValueError(f"Next.js requires Node.js 20.9 or newer; found {actual}.")
+
+
+def _provision_nextjs(destination: Path) -> None:
+    _ensure_next_prerequisites()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        destination.rmdir()
+    argv = (
+        "npx",
+        "--yes",
+        "create-next-app@latest",
+        str(destination),
+        "--ts",
+        "--eslint",
+        "--tailwind",
+        "--app",
+        "--src-dir",
+        "--turbopack",
+        "--import-alias",
+        "@/*",
+        "--use-npm",
+        "--disable-git",
+        "--yes",
+    )
+    result = run_command(
+        argv,
+        cwd=destination.parent,
+        timeout=1200,
+        stdout_limit=24_000,
+        stderr_limit=12_000,
+    )
+    if result["returncode"] != 0:
+        raise _command_failure("Next.js provisioning", result)
+    required = (destination / "package.json", destination / "src" / "app")
+    if not required[0].is_file() or not required[1].is_dir():
+        raise ValueError("Next.js provisioning completed without the expected package.json and src/app layout.")
+
+
+def _write_fastapi_source(destination: Path) -> None:
+    (destination / "src").mkdir(parents=True, exist_ok=True)
+    (destination / "tests").mkdir(parents=True, exist_ok=True)
+    (destination / "src" / "main.py").write_text(
+        "from fastapi import FastAPI\n\n"
+        "app = FastAPI(title=\"DPSR FastAPI Service\")\n\n"
+        "@app.get(\"/health\")\n"
+        "def health() -> dict[str, str]:\n"
+        "    return {\"status\": \"ok\"}\n",
+        encoding="utf-8",
+    )
+    (destination / "tests" / "test_health.py").write_text(
+        "from fastapi.testclient import TestClient\n\n"
+        "from src.main import app\n\n"
+        "client = TestClient(app)\n\n"
+        "def test_health() -> None:\n"
+        "    response = client.get(\"/health\")\n"
+        "    assert response.status_code == 200\n"
+        "    assert response.json() == {\"status\": \"ok\"}\n",
+        encoding="utf-8",
+    )
+    (destination / "requirements.txt").write_text(
+        "fastapi>=0.116,<1\n"
+        "uvicorn[standard]>=0.35,<1\n"
+        "pytest>=8,<10\n"
+        "httpx>=0.28,<1\n",
+        encoding="utf-8",
+    )
+    (destination / ".gitignore").write_text(
+        ".venv/\n__pycache__/\n.pytest_cache/\n*.py[cod]\n.env\n",
+        encoding="utf-8",
+    )
+
+
+def _provision_fastapi(destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    _write_fastapi_source(destination)
+    venv = run_command(("python3", "-m", "venv", str(destination / ".venv")), cwd=destination, timeout=120)
+    if venv["returncode"] != 0:
+        raise _command_failure("FastAPI virtual environment creation", venv)
+    pip = destination / ".venv" / "bin" / "python"
+    install = run_command(
+        (str(pip), "-m", "pip", "install", "--disable-pip-version-check", "-q", "-r", "requirements.txt"),
+        cwd=destination,
+        timeout=600,
+        stdout_limit=12_000,
+        stderr_limit=12_000,
+    )
+    if install["returncode"] != 0:
+        raise _command_failure("FastAPI dependency installation", install)
+
+
 def _seed_layout(target: Path, profile: Profile) -> None:
     scaffold = profile.scaffold
     if scaffold == "fullstack-web":
@@ -62,19 +180,49 @@ def _seed_layout(target: Path, profile: Profile) -> None:
         (target / "src").mkdir(parents=True, exist_ok=True)
 
 
+def _write_platform_metadata(destination: Path, name: str, profile: Profile) -> None:
+    (destination / "dpsr.toml").write_text(render_manifest(name, profile), encoding="utf-8")
+    marker = f"\n## DPSR\n\nManaged profile: `{profile.name}`.\n\n{profile.description}\n"
+    readme = destination / "README.md"
+    if readme.exists():
+        text = readme.read_text(encoding="utf-8", errors="replace").rstrip()
+        if "## DPSR" not in text:
+            readme.write_text(text + marker, encoding="utf-8")
+    else:
+        readme.write_text(f"# {name}\n" + marker, encoding="utf-8")
+
+
+def _managed_destination(destination: Path) -> bool:
+    try:
+        destination.relative_to(PROJECTS_ROOT.resolve())
+        return True
+    except ValueError:
+        return False
+
+
 def init_project(name: str, profile_name: str, target: Path | None = None):
     normalized = name.strip().lower()
     if not PROJECT_NAME.fullmatch(normalized):
         raise ValueError("Project name must be 2-63 lowercase letters, digits, dots, underscores, or hyphens.")
     profile = get_profile(profile_name)
-    destination = (target or (PROJECTS_ROOT / normalized)).resolve()
-    if destination.exists() and any(destination.iterdir()):
+    destination = (target or (PROJECTS_ROOT / normalized)).expanduser().resolve()
+    existed = destination.exists()
+    if existed and any(destination.iterdir()):
         raise ValueError(f"Project directory is not empty: {destination}")
-    destination.mkdir(parents=True, exist_ok=True)
-    _seed_layout(destination, profile)
-    (destination / "dpsr.toml").write_text(render_manifest(normalized, profile), encoding="utf-8")
-    (destination / "README.md").write_text(
-        f"# {normalized}\n\nDPSR profile: `{profile.name}`\n\n{profile.description}\n",
-        encoding="utf-8",
-    )
-    return register_project(destination)
+    if existed and not destination.is_dir():
+        raise ValueError(f"Project path is not a directory: {destination}")
+
+    try:
+        if profile.scaffold == "nextjs":
+            _provision_nextjs(destination)
+        elif profile.scaffold == "fastapi":
+            _provision_fastapi(destination)
+        else:
+            destination.mkdir(parents=True, exist_ok=True)
+            _seed_layout(destination, profile)
+        _write_platform_metadata(destination, normalized, profile)
+        return register_project(destination)
+    except Exception:
+        if not existed and _managed_destination(destination):
+            shutil.rmtree(destination, ignore_errors=True)
+        raise

--- a/security_lab/platform/scaffold.py
+++ b/security_lab/platform/scaffold.py
@@ -207,10 +207,10 @@ def init_project(name: str, profile_name: str, target: Path | None = None):
     profile = get_profile(profile_name)
     destination = (target or (PROJECTS_ROOT / normalized)).expanduser().resolve()
     existed = destination.exists()
-    if existed and any(destination.iterdir()):
-        raise ValueError(f"Project directory is not empty: {destination}")
     if existed and not destination.is_dir():
         raise ValueError(f"Project path is not a directory: {destination}")
+    if existed and any(destination.iterdir()):
+        raise ValueError(f"Project directory is not empty: {destination}")
 
     try:
         if profile.scaffold == "nextjs":

--- a/tests/test_platform_core.py
+++ b/tests/test_platform_core.py
@@ -5,7 +5,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from security_lab.platform import api, cli, jobs, registry
+from security_lab.platform import api, cli, jobs, registry, scaffold
 from security_lab.platform.models import CommandSpec, Project, load_project_manifest
 from security_lab.platform.profiles import load_profiles
 from security_lab.platform.runners import get_runner
@@ -101,6 +101,78 @@ timeout = 30
         with mock.patch.object(api, "get_project", return_value=project):
             with self.assertRaisesRegex(ValueError, "not eligible for synchronous MCP execution"):
                 api.execute_job("demo", "dev")
+
+    def test_nextjs_provisioning_is_explicit_noninteractive_and_registered(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            base = Path(temp)
+            project_root = base / "demo-next"
+            state = base / "state"
+            calls: list[tuple[str, ...]] = []
+
+            def fake_run(argv, **_kwargs):
+                command = tuple(str(item) for item in argv)
+                calls.append(command)
+                if command[:2] == ("node", "--version"):
+                    return {"returncode": 0, "stdout": "v22.18.0\n", "stderr": "", "command": list(command)}
+                if command[:3] == ("npx", "--yes", "create-next-app@latest"):
+                    target = Path(command[3])
+                    (target / "src" / "app").mkdir(parents=True)
+                    (target / "package.json").write_text('{"scripts":{"lint":"eslint","build":"next build"}}\n', encoding="utf-8")
+                    (target / "README.md").write_text("# Next app\n", encoding="utf-8")
+                    return {"returncode": 0, "stdout": "created", "stderr": "", "command": list(command)}
+                raise AssertionError(f"unexpected command: {command}")
+
+            with (
+                mock.patch.object(registry, "STATE_ROOT", state),
+                mock.patch.object(registry, "REGISTRY_PATH", state / "projects.json"),
+                mock.patch.object(scaffold, "run_command", side_effect=fake_run),
+            ):
+                project = scaffold.init_project("demo-next", "nextjs", project_root)
+
+            self.assertEqual(project.profile, "nextjs")
+            self.assertTrue((project_root / "dpsr.toml").is_file())
+            create = calls[1]
+            for expected in ("--ts", "--eslint", "--tailwind", "--app", "--src-dir", "--turbopack", "--use-npm", "--disable-git", "--yes"):
+                self.assertIn(expected, create)
+            self.assertNotIn("sh", create)
+
+    def test_nextjs_rejects_unsupported_node_before_scaffolding(self) -> None:
+        result = {"returncode": 0, "stdout": "v18.20.0\n", "stderr": "", "command": ["node", "--version"]}
+        with mock.patch.object(scaffold, "run_command", return_value=result):
+            with self.assertRaisesRegex(ValueError, "Node.js 20.9 or newer"):
+                scaffold._ensure_next_prerequisites()
+
+    def test_fastapi_provisioning_creates_isolated_app(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            base = Path(temp)
+            project_root = base / "demo-api"
+            state = base / "state"
+            calls: list[tuple[str, ...]] = []
+
+            def fake_run(argv, **_kwargs):
+                command = tuple(str(item) for item in argv)
+                calls.append(command)
+                if command[:3] == ("python3", "-m", "venv"):
+                    (project_root / ".venv" / "bin").mkdir(parents=True)
+                    return {"returncode": 0, "stdout": "", "stderr": "", "command": list(command)}
+                if len(command) >= 4 and command[1:4] == ("-m", "pip", "install"):
+                    return {"returncode": 0, "stdout": "", "stderr": "", "command": list(command)}
+                raise AssertionError(f"unexpected command: {command}")
+
+            with (
+                mock.patch.object(registry, "STATE_ROOT", state),
+                mock.patch.object(registry, "REGISTRY_PATH", state / "projects.json"),
+                mock.patch.object(scaffold, "run_command", side_effect=fake_run),
+            ):
+                project = scaffold.init_project("demo-api", "fastapi", project_root)
+
+            self.assertEqual(project.profile, "fastapi")
+            self.assertTrue((project_root / "src" / "main.py").is_file())
+            self.assertTrue((project_root / "tests" / "test_health.py").is_file())
+            self.assertTrue((project_root / "requirements.txt").is_file())
+            self.assertTrue((project_root / "dpsr.toml").is_file())
+            self.assertEqual(calls[0][:3], ("python3", "-m", "venv"))
+            self.assertIn("requirements.txt", calls[1])
 
     def test_command_string_is_tokenized_without_shell(self) -> None:
         command = CommandSpec.from_value("python3 -c 'print(123)'")


### PR DESCRIPTION
Adds real framework provisioning to DPSR project initialization.

Next.js:
- enforces Node.js 20.9+
- invokes official create-next-app noninteractively with explicit TypeScript, ESLint, Tailwind, App Router, src/, Turbopack, npm, and disabled nested Git
- preserves framework README and appends DPSR metadata
- registers the generated project with lint/build/dev/start commands

FastAPI:
- creates an isolated .venv
- installs project-local FastAPI/Uvicorn/pytest/httpx dependencies
- creates /health and a pytest health test
- registers lint/test/dev commands

Also adds transactional cleanup for failed managed-project provisioning, destination validation, documentation, and mocked regression tests for provisioning boundaries.