### PR TITLE
Platform v2: integrated full-stack provisioning and project lifecycle

### DIFF
--- a/platform/PROVISIONING.md
+++ b/platform/PROVISIONING.md
@@ -1,6 +1,6 @@
 # DPSR framework provisioning
 
-DPSR project initialization is responsible for creating a usable framework project, adding `dpsr.toml`, and registering the project in persistent platform state.
+DPSR project initialization creates a usable framework project, adds `dpsr.toml`, and registers the project in persistent platform state.
 
 ## Next.js
 
@@ -10,8 +10,28 @@ Verification runs the profile's bounded `lint` and `build` jobs. Development and
 
 ## FastAPI
 
-The `fastapi` profile creates an isolated `.venv`, installs project-local dependencies, writes a health endpoint and a pytest health check, and registers bounded `lint` and `test` jobs. Its development server is intentionally long-running and is not eligible for synchronous MCP job execution.
+The `fastapi` profile creates an isolated `.venv`, installs project-local dependencies, writes a `/health` endpoint and pytest health check, and registers bounded `lint` and `test` jobs. Its development server is intentionally long-running and is not eligible for synchronous MCP job execution.
+
+## Full-stack web
+
+The `fullstack-web` profile composes the same Next.js and FastAPI provisioners under `apps/web` and `apps/api`. It also creates:
+
+- a PostgreSQL service and persistent volume in `compose.yaml`
+- Dockerfiles for the web and API applications
+- a generated local database password stored only in the project's ignored `.env`
+- an `.env.example` without credentials
+- a Next.js `/api/backend-health` route that reaches the FastAPI health endpoint through `API_INTERNAL_URL`
+- a shared-package area and infrastructure directory
+- bounded project-level `lint`, `test`, and `build` jobs
+
+The ordinary `build` job validates the Next.js production build and Compose configuration without building container images. `container-build` is available as a separate bounded job. `dev` remains long-running and is not eligible for synchronous MCP execution.
 
 ## Failure behavior
 
 New projects created under the managed DPSR project root are removed when provisioning fails, allowing a clean retry. Custom external paths are never recursively deleted by the provisioner.
+
+## Project removal
+
+`dpsr project remove` removes only a registry entry and leaves files untouched.
+
+`dpsr project delete` and the structured `platform_project_delete` MCP tool recursively remove the project directory only after resolving and proving that the registered project is a child of the managed DPSR project root. Registered projects outside that root cannot be deleted through this operation.

--- a/platform/profiles/fullstack-web.json
+++ b/platform/profiles/fullstack-web.json
@@ -3,16 +3,19 @@
     "name": "fullstack-web",
     "title": "Full-Stack Web",
     "category": "web",
-    "description": "Multi-service web application profile for frontend, API, shared packages, database, containers, CI, previews, and deployment automation.",
+    "description": "Integrated Next.js and FastAPI application with PostgreSQL, containers, health bridging, CI, previews, and deployment automation.",
     "runner": "local",
     "stack": ["nextjs", "fastapi", "postgresql", "docker"],
-    "capabilities": ["frontend", "api", "database", "containers", "preview", "ci", "deploy"],
+    "capabilities": ["frontend", "api", "database", "containers", "health", "preview", "ci", "deploy"],
     "scaffold": "fullstack-web"
   },
   "commands": {
-    "build": {"argv": ["docker", "compose", "build"], "cwd": ".", "timeout": 1800},
-    "dev": {"argv": ["docker", "compose", "up"], "cwd": ".", "timeout": 86400},
+    "lint": {"argv": ["python3", "tools/stack_check.py", "lint"], "cwd": ".", "timeout": 1200},
+    "test": {"argv": ["python3", "tools/stack_check.py", "test"], "cwd": ".", "timeout": 1200},
+    "build": {"argv": ["python3", "tools/stack_check.py", "build"], "cwd": ".", "timeout": 2400},
+    "container-build": {"argv": ["docker", "compose", "build"], "cwd": ".", "timeout": 3600},
+    "dev": {"argv": ["docker", "compose", "up", "--build"], "cwd": ".", "timeout": 86400},
     "down": {"argv": ["docker", "compose", "down"], "cwd": ".", "timeout": 120}
   },
-  "services": {"web": 3000, "api": 8000, "postgres": 5432}
+  "services": {"web": 3000, "api": 8000}
 }

--- a/security_lab/mcp_server.py
+++ b/security_lab/mcp_server.py
@@ -107,6 +107,12 @@ def platform_project_init(name: str, profile_name: str) -> dict[str, Any]:
 
 
 @mcp.tool()
+def platform_project_delete(name: str) -> dict[str, Any]:
+    """Delete one registered project only when it resides inside the managed DPSR project workspace."""
+    return platform_api.delete_project(name)
+
+
+@mcp.tool()
 def platform_job(job_id: str) -> dict[str, Any]:
     """Return one persisted DPSR job by id."""
     return platform_api.job(job_id)

--- a/security_lab/platform/api.py
+++ b/security_lab/platform/api.py
@@ -5,7 +5,7 @@ from typing import Any
 from .jobs import get_job, list_jobs, run_job
 from .models import Profile, Project
 from .profiles import get_profile, load_profiles
-from .registry import get_project, list_projects
+from .registry import delete_managed_project, get_project, list_projects
 from .runners import RUNNERS
 from .scaffold import init_project
 
@@ -82,6 +82,16 @@ def project(name: str) -> dict[str, Any]:
 
 def create_project(name: str, profile_name: str) -> dict[str, Any]:
     return project_row(init_project(name, profile_name))
+
+
+def delete_project(name: str) -> dict[str, Any]:
+    project_model = delete_managed_project(name)
+    return {
+        "ok": True,
+        "name": project_model.name,
+        "path": str(project_model.path),
+        "profile": project_model.profile,
+    }
 
 
 def execute_job(project_name: str, command_name: str) -> dict[str, Any]:

--- a/security_lab/platform/cli.py
+++ b/security_lab/platform/cli.py
@@ -8,7 +8,7 @@ from security_lab.common import ROOT
 
 from .jobs import get_job, list_jobs, run_job
 from .profiles import get_profile, load_profiles
-from .registry import get_project, list_projects, register_project, unregister_project
+from .registry import delete_managed_project, get_project, list_projects, register_project, unregister_project
 from .runners import RUNNERS
 from .scaffold import init_project
 
@@ -79,6 +79,15 @@ def cmd_project(args: argparse.Namespace) -> int:
             raise ValueError(f"Unknown project: {args.name}")
         print(f"Removed project registry entry: {args.name}")
         return 0
+    if action == "delete":
+        project = delete_managed_project(args.name)
+        print(json.dumps({
+            "deleted": True,
+            "name": project.name,
+            "path": str(project.path),
+            "profile": project.profile,
+        }, indent=2, sort_keys=True))
+        return 0
     if action == "init":
         target = Path(args.path).expanduser() if args.path else None
         project = init_project(args.name, args.profile, target)
@@ -140,6 +149,8 @@ def build_parser() -> argparse.ArgumentParser:
     project_register.add_argument("path")
     project_remove = project_sub.add_parser("remove")
     project_remove.add_argument("name")
+    project_delete = project_sub.add_parser("delete")
+    project_delete.add_argument("name")
     project_init = project_sub.add_parser("init")
     project_init.add_argument("name")
     project_init.add_argument("--profile", required=True)

--- a/security_lab/platform/registry.py
+++ b/security_lab/platform/registry.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from typing import Any
 
 from .models import Project, load_project_manifest
-from .paths import STATE_ROOT
+from .paths import PROJECTS_ROOT, STATE_ROOT
 
 REGISTRY_PATH = STATE_ROOT / "projects.json"
 
@@ -67,3 +68,21 @@ def get_project(name: str) -> Project:
     except KeyError as exc:
         raise ValueError(f"Unknown project: {name}") from exc
     return load_project_manifest(Path(str(entry["path"])))
+
+
+def delete_managed_project(name: str) -> Project:
+    project = get_project(name)
+    root = PROJECTS_ROOT.resolve()
+    target = project.path.resolve()
+    try:
+        relative = target.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("Only projects inside the managed DPSR project root can be deleted.") from exc
+    if not relative.parts:
+        raise ValueError("Refusing to delete the managed DPSR project root.")
+    if not target.is_dir():
+        raise ValueError(f"Managed project directory is missing: {target}")
+    shutil.rmtree(target)
+    if not unregister_project(name):
+        raise ValueError(f"Project registry entry disappeared during deletion: {name}")
+    return project

--- a/security_lab/platform/scaffold.py
+++ b/security_lab/platform/scaffold.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import secrets
 import shutil
 from pathlib import Path
 
@@ -167,6 +168,159 @@ def _provision_fastapi(destination: Path) -> None:
         raise _command_failure("FastAPI dependency installation", install)
 
 
+def _write_fullstack_bridge(web: Path) -> None:
+    route = web / "src" / "app" / "api" / "backend-health" / "route.ts"
+    route.parent.mkdir(parents=True, exist_ok=True)
+    route.write_text(
+        'import { NextResponse } from "next/server";\n\n'
+        'export const dynamic = "force-dynamic";\n\n'
+        "export async function GET() {\n"
+        '  const baseUrl = process.env.API_INTERNAL_URL ?? "http://127.0.0.1:8000";\n'
+        "  try {\n"
+        '    const response = await fetch(`${baseUrl}/health`, { cache: "no-store" });\n'
+        "    const payload = await response.json();\n"
+        "    return NextResponse.json({ ok: response.ok, api: payload }, { status: response.ok ? 200 : 502 });\n"
+        "  } catch {\n"
+        "    return NextResponse.json({ ok: false, api: null }, { status: 503 });\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_fullstack_files(destination: Path) -> None:
+    web = destination / "apps" / "web"
+    api = destination / "apps" / "api"
+    (destination / "packages" / "shared").mkdir(parents=True, exist_ok=True)
+    (destination / "infra").mkdir(parents=True, exist_ok=True)
+    (destination / "tools").mkdir(parents=True, exist_ok=True)
+    _write_fullstack_bridge(web)
+
+    (web / "Dockerfile").write_text(
+        "FROM node:22-alpine AS deps\n"
+        "WORKDIR /app\n"
+        "COPY package*.json ./\n"
+        "RUN npm ci\n\n"
+        "FROM node:22-alpine AS builder\n"
+        "WORKDIR /app\n"
+        "COPY --from=deps /app/node_modules ./node_modules\n"
+        "COPY . .\n"
+        "RUN npm run build\n\n"
+        "FROM node:22-alpine AS runtime\n"
+        "ENV NODE_ENV=production\n"
+        "WORKDIR /app\n"
+        "COPY --from=builder /app ./\n"
+        "EXPOSE 3000\n"
+        'CMD ["npm", "run", "start", "--", "--hostname", "0.0.0.0", "--port", "3000"]\n',
+        encoding="utf-8",
+    )
+    (web / ".dockerignore").write_text("node_modules\n.next\n.git\n", encoding="utf-8")
+
+    (api / "Dockerfile").write_text(
+        "FROM python:3.13-slim\n"
+        "WORKDIR /app\n"
+        "COPY requirements.txt ./\n"
+        "RUN python -m pip install --no-cache-dir --disable-pip-version-check -r requirements.txt\n"
+        "COPY src ./src\n"
+        "WORKDIR /app/src\n"
+        "EXPOSE 8000\n"
+        'CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]\n',
+        encoding="utf-8",
+    )
+    (api / ".dockerignore").write_text(".venv\n__pycache__\n.pytest_cache\n.git\n", encoding="utf-8")
+
+    (destination / "compose.yaml").write_text(
+        "services:\n"
+        "  postgres:\n"
+        "    image: postgres:17-alpine\n"
+        "    environment:\n"
+        "      POSTGRES_DB: dpsr\n"
+        "      POSTGRES_USER: dpsr\n"
+        "      POSTGRES_PASSWORD: ${DPSR_DB_PASSWORD}\n"
+        "    volumes:\n"
+        "      - postgres-data:/var/lib/postgresql/data\n"
+        "    healthcheck:\n"
+        "      test: [\"CMD-SHELL\", \"pg_isready -U dpsr -d dpsr\"]\n"
+        "      interval: 5s\n"
+        "      timeout: 3s\n"
+        "      retries: 12\n"
+        "  api:\n"
+        "    build: ./apps/api\n"
+        "    environment:\n"
+        "      DATABASE_URL: postgresql://dpsr:${DPSR_DB_PASSWORD}@postgres:5432/dpsr\n"
+        "    ports:\n"
+        "      - \"8000:8000\"\n"
+        "    depends_on:\n"
+        "      postgres:\n"
+        "        condition: service_healthy\n"
+        "  web:\n"
+        "    build: ./apps/web\n"
+        "    environment:\n"
+        "      API_INTERNAL_URL: http://api:8000\n"
+        "    ports:\n"
+        "      - \"3000:3000\"\n"
+        "    depends_on:\n"
+        "      - api\n"
+        "volumes:\n"
+        "  postgres-data:\n",
+        encoding="utf-8",
+    )
+
+    (destination / ".env").write_text(f"DPSR_DB_PASSWORD={secrets.token_urlsafe(24)}\n", encoding="utf-8")
+    (destination / ".env.example").write_text("DPSR_DB_PASSWORD=\n", encoding="utf-8")
+    (destination / ".gitignore").write_text(".env\n", encoding="utf-8")
+    (destination / "packages" / "shared" / "README.md").write_text(
+        "# Shared packages\n\nPlace cross-application schemas, generated clients, and shared types here.\n",
+        encoding="utf-8",
+    )
+
+    (destination / "tools" / "stack_check.py").write_text(
+        "from __future__ import annotations\n\n"
+        "import subprocess\n"
+        "import sys\n"
+        "from pathlib import Path\n\n"
+        "ROOT = Path(__file__).resolve().parents[1]\n"
+        "WEB = ROOT / 'apps' / 'web'\n"
+        "API = ROOT / 'apps' / 'api'\n"
+        "API_PYTHON = str(API / '.venv' / 'bin' / 'python')\n\n"
+        "def run(argv: list[str], cwd: Path) -> int:\n"
+        "    completed = subprocess.run(argv, cwd=cwd, check=False)\n"
+        "    return completed.returncode\n\n"
+        "def main() -> int:\n"
+        "    action = sys.argv[1] if len(sys.argv) == 2 else ''\n"
+        "    steps: dict[str, list[tuple[list[str], Path]]] = {\n"
+        "        'lint': [\n"
+        "            (['npm', 'run', 'lint'], WEB),\n"
+        "            ([API_PYTHON, '-m', 'compileall', '-q', 'src', 'tests'], API),\n"
+        "        ],\n"
+        "        'test': [([API_PYTHON, '-m', 'pytest', '-q'], API)],\n"
+        "        'build': [\n"
+        "            (['npm', 'run', 'build'], WEB),\n"
+        "            (['docker', 'compose', 'config', '--quiet'], ROOT),\n"
+        "        ],\n"
+        "    }\n"
+        "    selected = steps.get(action)\n"
+        "    if selected is None:\n"
+        "        print('usage: stack_check.py {lint|test|build}', file=sys.stderr)\n"
+        "        return 2\n"
+        "    for argv, cwd in selected:\n"
+        "        result = run(argv, cwd)\n"
+        "        if result != 0:\n"
+        "            return result\n"
+        "    return 0\n\n"
+        "if __name__ == '__main__':\n"
+        "    raise SystemExit(main())\n",
+        encoding="utf-8",
+    )
+
+
+def _provision_fullstack(destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    _provision_nextjs(destination / "apps" / "web")
+    _provision_fastapi(destination / "apps" / "api")
+    _write_fullstack_files(destination)
+
+
 def _seed_layout(target: Path, profile: Profile) -> None:
     scaffold = profile.scaffold
     if scaffold == "fullstack-web":
@@ -217,6 +371,8 @@ def init_project(name: str, profile_name: str, target: Path | None = None):
             _provision_nextjs(destination)
         elif profile.scaffold == "fastapi":
             _provision_fastapi(destination)
+        elif profile.scaffold == "fullstack-web":
+            _provision_fullstack(destination)
         else:
             destination.mkdir(parents=True, exist_ok=True)
             _seed_layout(destination, profile)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -22,6 +22,7 @@ class MCPServerTests(unittest.IsolatedAsyncioTestCase):
                 "platform_profile",
                 "platform_project",
                 "platform_project_init",
+                "platform_project_delete",
                 "platform_job",
                 "platform_job_run",
             }

--- a/tests/test_platform_core.py
+++ b/tests/test_platform_core.py
@@ -174,6 +174,102 @@ timeout = 30
             self.assertEqual(calls[0][:3], ("python3", "-m", "venv"))
             self.assertIn("requirements.txt", calls[1])
 
+    def test_fullstack_provisioning_composes_proven_framework_provisioners(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            base = Path(temp)
+            project_root = base / "demo-stack"
+            state = base / "state"
+
+            def fake_next(target: Path) -> None:
+                (target / "src" / "app").mkdir(parents=True)
+                (target / "package.json").write_text("{}\n", encoding="utf-8")
+                (target / "README.md").write_text("# Web\n", encoding="utf-8")
+
+            def fake_api(target: Path) -> None:
+                (target / "src").mkdir(parents=True)
+                (target / "tests").mkdir(parents=True)
+                (target / ".venv" / "bin").mkdir(parents=True)
+                (target / "requirements.txt").write_text("fastapi\n", encoding="utf-8")
+
+            with (
+                mock.patch.object(registry, "STATE_ROOT", state),
+                mock.patch.object(registry, "REGISTRY_PATH", state / "projects.json"),
+                mock.patch.object(scaffold, "_provision_nextjs", side_effect=fake_next) as next_mock,
+                mock.patch.object(scaffold, "_provision_fastapi", side_effect=fake_api) as api_mock,
+            ):
+                project = scaffold.init_project("demo-stack", "fullstack-web", project_root)
+
+            self.assertEqual(project.profile, "fullstack-web")
+            next_mock.assert_called_once_with(project_root / "apps" / "web")
+            api_mock.assert_called_once_with(project_root / "apps" / "api")
+            self.assertTrue((project_root / "compose.yaml").is_file())
+            self.assertTrue((project_root / "apps" / "web" / "Dockerfile").is_file())
+            self.assertTrue((project_root / "apps" / "api" / "Dockerfile").is_file())
+            self.assertTrue((project_root / "apps" / "web" / "src" / "app" / "api" / "backend-health" / "route.ts").is_file())
+            self.assertTrue((project_root / "tools" / "stack_check.py").is_file())
+            self.assertTrue((project_root / ".env").is_file())
+            self.assertTrue((project_root / ".env.example").is_file())
+            self.assertTrue((project_root / "dpsr.toml").is_file())
+            self.assertEqual(project.services, {"api": 8000, "web": 3000})
+
+    def test_managed_delete_removes_only_project_root_children(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            base = Path(temp)
+            managed = base / "managed"
+            state = base / "state"
+            project_root = managed / "delete-me"
+            project_root.mkdir(parents=True)
+            (project_root / "dpsr.toml").write_text(
+                """
+[project]
+name = "delete-me"
+profile = "generic"
+[runner]
+type = "local"
+""".strip() + "\n",
+                encoding="utf-8",
+            )
+            with (
+                mock.patch.object(registry, "PROJECTS_ROOT", managed),
+                mock.patch.object(registry, "STATE_ROOT", state),
+                mock.patch.object(registry, "REGISTRY_PATH", state / "projects.json"),
+            ):
+                registry.register_project(project_root)
+                deleted = registry.delete_managed_project("delete-me")
+                self.assertEqual(deleted.name, "delete-me")
+                self.assertFalse(project_root.exists())
+                with self.assertRaisesRegex(ValueError, "Unknown project"):
+                    registry.get_project("delete-me")
+
+    def test_managed_delete_refuses_registered_external_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            base = Path(temp)
+            managed = base / "managed"
+            external = base / "external"
+            state = base / "state"
+            managed.mkdir()
+            external.mkdir()
+            (external / "dpsr.toml").write_text(
+                """
+[project]
+name = "external"
+profile = "generic"
+[runner]
+type = "local"
+""".strip() + "\n",
+                encoding="utf-8",
+            )
+            with (
+                mock.patch.object(registry, "PROJECTS_ROOT", managed),
+                mock.patch.object(registry, "STATE_ROOT", state),
+                mock.patch.object(registry, "REGISTRY_PATH", state / "projects.json"),
+            ):
+                registry.register_project(external)
+                with self.assertRaisesRegex(ValueError, "managed DPSR project root"):
+                    registry.delete_managed_project("external")
+                self.assertTrue(external.is_dir())
+                self.assertEqual(registry.get_project("external").path, external.resolve())
+
     def test_command_string_is_tokenized_without_shell(self) -> None:
         command = CommandSpec.from_value("python3 -c 'print(123)'")
         self.assertEqual(command.argv[0], "python3")


### PR DESCRIPTION
Builds the `fullstack-web` profile from the proven Next.js and FastAPI provisioners and adds guarded managed-project deletion.

Full-stack provisioning:
- real Next.js app under `apps/web`
- isolated FastAPI app under `apps/api`
- PostgreSQL 17 service with generated project-local password in ignored `.env`
- Dockerfiles and Compose wiring for web/API/database
- Next.js `/api/backend-health` route to FastAPI
- shared-package and infrastructure areas
- bounded project-level lint, test, build, and container-build commands

Project lifecycle:
- `dpsr project delete`
- structured `platform_project_delete` MCP tool
- recursive deletion only after resolving the registered project beneath the managed DPSR project root
- external registered paths are explicitly refused

Includes regression coverage for composed provisioning, delete boundary enforcement, and MCP tool discovery.