### PR TITLE
Platform v2: repository publishing and GitHub Actions runner

### DIFF
--- a/admin/runner-auth-control
+++ b/admin/runner-auth-control
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_ROOT="/workspaces/.dpsr"
+CONFIG_DIR="$STATE_ROOT/runner-gh"
+PIDFILE="$ROOT/.runner-auth.pid"
+LOGFILE="$ROOT/reports/runner-auth.log"
+
+read_pid() {
+  if [ -f "$PIDFILE" ]; then
+    cat "$PIDFILE" 2>/dev/null || true
+  fi
+}
+
+is_running() {
+  local pid
+  pid="$(read_pid)"
+  [ -n "$pid" ] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+show_log() {
+  if [ -f "$LOGFILE" ]; then
+    python3 - "$LOGFILE" <<'PY'
+import re
+import sys
+from pathlib import Path
+text = Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace")
+text = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text)
+lines = [line.rstrip() for line in text.splitlines() if line.strip()]
+print("\n".join(lines[-40:]))
+PY
+  fi
+}
+
+start_auth() {
+  mkdir -p "$ROOT/reports" "$CONFIG_DIR"
+  chmod 700 "$STATE_ROOT" "$CONFIG_DIR" 2>/dev/null || true
+  if is_running; then
+    printf 'Runner authorization already running: pid=%s\n' "$(read_pid)"
+    show_log
+    return 0
+  fi
+  rm -f "$PIDFILE"
+  : > "$LOGFILE"
+  nohup env -u GH_TOKEN -u GITHUB_TOKEN \
+    GH_CONFIG_DIR="$CONFIG_DIR" \
+    GH_PROMPT_DISABLED=1 \
+    BROWSER=true \
+    gh auth login \
+      --hostname github.com \
+      --git-protocol https \
+      --web \
+      --scopes repo,workflow \
+      >>"$LOGFILE" 2>&1 </dev/null &
+  local pid=$!
+  printf '%s\n' "$pid" > "$PIDFILE"
+  sleep 3
+  printf 'Runner authorization started: pid=%s\n' "$pid"
+  show_log
+}
+
+status_auth() {
+  if is_running; then
+    printf 'Runner authorization waiting: pid=%s\n' "$(read_pid)"
+  else
+    rm -f "$PIDFILE"
+    printf 'Runner authorization process not running.\n'
+  fi
+  show_log
+}
+
+stop_auth() {
+  if is_running; then
+    kill "$(read_pid)" 2>/dev/null || true
+  fi
+  rm -f "$PIDFILE"
+  printf 'Runner authorization stopped.\n'
+}
+
+case "${1:-status}" in
+  start) start_auth ;;
+  status) status_auth ;;
+  stop) stop_auth ;;
+  *)
+    printf 'Usage: %s {start|status|stop}\n' "$0" >&2
+    exit 2
+    ;;
+esac

--- a/admin/runner-credential-status
+++ b/admin/runner-credential-status
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+exec python3 -m security_lab.platform.cli runner status

--- a/security_lab/platform/api.py
+++ b/security_lab/platform/api.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from .jobs import get_job, list_jobs, run_job
+from .github_actions import auth_status as github_actions_auth_status
+from .github_actions import publish_project as publish_github_project
+from .github_actions import repository_binding
+from .jobs import list_jobs, refresh_job, refresh_pending_jobs, run_job
 from .mobile import MOBILE_PROFILES, init_mobile_project
 from .models import Profile, Project
 from .profiles import get_profile, load_profiles
@@ -30,6 +33,7 @@ def profile_row(profile: Profile) -> dict[str, Any]:
 
 
 def project_row(project: Project) -> dict[str, Any]:
+    binding = repository_binding(project)
     return {
         "name": project.name,
         "path": str(project.path),
@@ -37,6 +41,9 @@ def project_row(project: Project) -> dict[str, Any]:
         "runner": project.runner,
         "commands": sorted(project.commands),
         "services": project.services,
+        "repository": binding["full_name"] or None,
+        "branch": binding["branch"] if binding["full_name"] else None,
+        "workflow": binding["workflow"] or None,
     }
 
 
@@ -52,7 +59,16 @@ def jobs(limit: int = 50) -> list[dict[str, Any]]:
     return list_jobs(max(1, min(limit, 500)))
 
 
+def runner_status() -> dict[str, Any]:
+    return {
+        "local": sorted(RUNNERS),
+        "external": list(EXTERNAL_RUNNERS),
+        "github_actions": github_actions_auth_status(),
+    }
+
+
 def snapshot(job_limit: int = 20) -> dict[str, Any]:
+    refresh_pending_jobs(min(max(job_limit, 1), 20))
     profile_rows = profiles()
     project_rows = projects()
     job_rows = jobs(job_limit)
@@ -66,10 +82,7 @@ def snapshot(job_limit: int = 20) -> dict[str, Any]:
             "projects": len(project_rows),
             "jobs": len(list_jobs(500)),
         },
-        "runners": {
-            "local": sorted(RUNNERS),
-            "external": list(EXTERNAL_RUNNERS),
-        },
+        "runners": runner_status(),
     }
 
 
@@ -85,6 +98,14 @@ def create_project(name: str, profile_name: str) -> dict[str, Any]:
     if profile_name in MOBILE_PROFILES:
         return project_row(init_mobile_project(name, profile_name))
     return project_row(init_project(name, profile_name))
+
+
+def publish_project(
+    name: str,
+    repository: str = "",
+    visibility: str = "private",
+) -> dict[str, Any]:
+    return publish_github_project(get_project(name), repository, visibility)
 
 
 def delete_project(name: str) -> dict[str, Any]:
@@ -106,7 +127,7 @@ def execute_job(project_name: str, command_name: str) -> dict[str, Any]:
         raise ValueError(
             f"Project '{project_name}' has no command '{command_name}'. Available: {available}"
         ) from exc
-    if command.timeout > MAX_STRUCTURED_JOB_TIMEOUT:
+    if project_model.runner != "github-actions" and command.timeout > MAX_STRUCTURED_JOB_TIMEOUT:
         raise ValueError(
             f"Command '{command_name}' is long-running ({command.timeout}s) and is not eligible for synchronous MCP execution."
         )
@@ -114,4 +135,4 @@ def execute_job(project_name: str, command_name: str) -> dict[str, Any]:
 
 
 def job(job_id: str) -> dict[str, Any]:
-    return get_job(job_id)
+    return refresh_job(job_id)

--- a/security_lab/platform/cli.py
+++ b/security_lab/platform/cli.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 from security_lab.common import ROOT
 
-from .jobs import get_job, list_jobs, run_job
+from .github_actions import auth_status as github_actions_auth_status
+from .github_actions import publish_project as publish_github_project
+from .github_actions import repository_binding
+from .jobs import list_jobs, refresh_job, run_job
 from .mobile import MOBILE_PROFILES, init_mobile_project
 from .profiles import get_profile, load_profiles
 from .registry import delete_managed_project, get_project, list_projects, register_project, unregister_project
@@ -15,6 +18,7 @@ from .scaffold import init_project
 
 
 def _project_row(project) -> dict[str, object]:
+    binding = repository_binding(project)
     return {
         "name": project.name,
         "profile": project.profile,
@@ -22,6 +26,9 @@ def _project_row(project) -> dict[str, object]:
         "path": str(project.path),
         "commands": sorted(project.commands),
         "services": project.services,
+        "repository": binding["full_name"] or None,
+        "branch": binding["branch"] if binding["full_name"] else None,
+        "workflow": binding["workflow"] or None,
     }
 
 
@@ -33,7 +40,11 @@ def cmd_status(_args: argparse.Namespace) -> int:
         "root": str(ROOT),
         "profiles": len(profiles),
         "projects": len(projects),
-        "runners": sorted(RUNNERS),
+        "runners": {
+            "local": sorted(RUNNERS),
+            "external": ["github-actions", "codespace"],
+            "github_actions": github_actions_auth_status(),
+        },
         "jobs": len(list_jobs(500)),
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
@@ -97,11 +108,16 @@ def cmd_project(args: argparse.Namespace) -> int:
             project = init_project(args.name, args.profile, target)
         print(json.dumps(_project_row(project), indent=2, sort_keys=True))
         return 0
+    if action == "publish":
+        project = get_project(args.name)
+        result = publish_github_project(project, args.repo or "", args.visibility)
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
     if action == "verify":
         project = get_project(args.name)
         if project.runner not in RUNNERS:
             raise ValueError(
-                f"Project '{args.name}' uses external runner '{project.runner}'; run its generated CI workflow to verify builds."
+                f"Project '{args.name}' uses external runner '{project.runner}'; publish it and use `dpsr job run` to dispatch its remote workflow."
             )
         selected = [name for name in ("lint", "test", "build") if name in project.commands]
         if not selected:
@@ -119,12 +135,12 @@ def cmd_job(args: argparse.Namespace) -> int:
     if args.job_command == "list":
         print(json.dumps(list_jobs(args.limit), indent=2, sort_keys=True))
         return 0
-    if args.job_command == "show":
-        print(json.dumps(get_job(args.id), indent=2, sort_keys=True))
+    if args.job_command in {"show", "refresh"}:
+        print(json.dumps(refresh_job(args.id), indent=2, sort_keys=True))
         return 0
     job = run_job(args.project, args.command_name)
     print(json.dumps(job, indent=2, sort_keys=True))
-    return 0 if job["state"] == "succeeded" else 1
+    return 1 if job["state"] == "failed" else 0
 
 
 def cmd_runner(args: argparse.Namespace) -> int:
@@ -133,6 +149,12 @@ def cmd_runner(args: argparse.Namespace) -> int:
             print(name)
         print("github-actions\texternal")
         print("codespace\texternal")
+        return 0
+    if args.runner_command == "status":
+        print(json.dumps({
+            "local": sorted(RUNNERS),
+            "github_actions": github_actions_auth_status(),
+        }, indent=2, sort_keys=True))
         return 0
     raise ValueError(f"Unsupported runner action: {args.runner_command}")
 
@@ -163,6 +185,10 @@ def build_parser() -> argparse.ArgumentParser:
     project_init.add_argument("name")
     project_init.add_argument("--profile", required=True)
     project_init.add_argument("--path")
+    project_publish = project_sub.add_parser("publish")
+    project_publish.add_argument("name")
+    project_publish.add_argument("--repo")
+    project_publish.add_argument("--visibility", choices=("private", "public"), default="private")
     project_verify = project_sub.add_parser("verify")
     project_verify.add_argument("name")
 
@@ -172,6 +198,8 @@ def build_parser() -> argparse.ArgumentParser:
     job_list.add_argument("--limit", type=int, default=50)
     job_show = job_sub.add_parser("show")
     job_show.add_argument("id")
+    job_refresh = job_sub.add_parser("refresh")
+    job_refresh.add_argument("id")
     job_run = job_sub.add_parser("run")
     job_run.add_argument("project")
     job_run.add_argument("command_name")
@@ -179,6 +207,7 @@ def build_parser() -> argparse.ArgumentParser:
     runner = sub.add_parser("runner")
     runner_sub = runner.add_subparsers(dest="runner_command", required=True)
     runner_sub.add_parser("list")
+    runner_sub.add_parser("status")
     return parser
 
 

--- a/security_lab/platform/github_actions.py
+++ b/security_lab/platform/github_actions.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess  # nosec B404
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .models import Project
+from .paths import PERSISTENT_ROOT, PROJECTS_ROOT
+from .registry import register_project
+
+RUNNER_GH_CONFIG = Path(
+    os.environ.get("DPSR_RUNNER_GH_CONFIG", str(PERSISTENT_ROOT / ".dpsr" / "runner-gh"))
+).expanduser()
+RUNNER_GIT_CONFIG = Path(
+    os.environ.get("DPSR_RUNNER_GIT_CONFIG", str(PERSISTENT_ROOT / ".dpsr" / "runner-gitconfig"))
+).expanduser()
+REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+REQUIRED_SCOPES = frozenset({"repo", "workflow"})
+ALLOWED_SCOPES = frozenset({"repo", "workflow", "read:org", "gist"})
+WORKFLOW_BY_PROFILE = {
+    "flutter": "flutter.yml",
+    "react-native": "react-native.yml",
+    "android": "android.yml",
+    "ios": "ios.yml",
+}
+ACTIVE_RUN_STATES = frozenset({"queued", "in_progress", "pending", "requested", "waiting"})
+
+
+def _utc() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _runner_env() -> dict[str, str]:
+    RUNNER_GH_CONFIG.mkdir(parents=True, exist_ok=True)
+    os.chmod(RUNNER_GH_CONFIG, 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
+    env = os.environ.copy()
+    env.pop("GH_TOKEN", None)
+    env.pop("GITHUB_TOKEN", None)
+    env["GH_CONFIG_DIR"] = str(RUNNER_GH_CONFIG)
+    env["GH_PROMPT_DISABLED"] = "1"
+    env["GIT_CONFIG_GLOBAL"] = str(RUNNER_GIT_CONFIG)
+    return env
+
+
+def _run(
+    argv: tuple[str, ...] | list[str],
+    *,
+    cwd: Path | None = None,
+    timeout: int = 120,
+) -> dict[str, Any]:
+    completed = subprocess.run(  # nosec B603
+        [str(item) for item in argv],
+        cwd=cwd,
+        env=_runner_env(),
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+    return {
+        "returncode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+    }
+
+
+def _gh(*args: str, cwd: Path | None = None, timeout: int = 120) -> dict[str, Any]:
+    return _run(("gh", *args), cwd=cwd, timeout=timeout)
+
+
+def _git(project: Project, *args: str, timeout: int = 120) -> dict[str, Any]:
+    return _run(("git", "-C", str(project.path), *args), cwd=project.path, timeout=timeout)
+
+
+def _detail(result: dict[str, Any]) -> str:
+    return str(result.get("stderr") or result.get("stdout") or "no process output").strip()
+
+
+def _require_ok(label: str, result: dict[str, Any]) -> dict[str, Any]:
+    if int(result.get("returncode", 1)) != 0:
+        raise ValueError(f"{label} failed: {_detail(result)}")
+    return result
+
+
+def _parse_scopes(text: str) -> set[str]:
+    match = re.search(r"Token scopes:\s*(.+)", text, re.IGNORECASE)
+    if not match:
+        return set()
+    return {item.strip(" '\"\t") for item in match.group(1).split(",") if item.strip(" '\"\t")}
+
+
+def auth_status() -> dict[str, Any]:
+    result = _gh("auth", "status", "--hostname", "github.com", timeout=20)
+    output = "\n".join(part for part in (result["stdout"].strip(), result["stderr"].strip()) if part)
+    scopes = _parse_scopes(output)
+    missing = sorted(REQUIRED_SCOPES - scopes)
+    unexpected = sorted(scopes - ALLOWED_SCOPES)
+    authenticated = result["returncode"] == 0
+    safe = authenticated and not missing and not unexpected
+    return {
+        "authenticated": authenticated,
+        "safe": safe,
+        "scopes": sorted(scopes),
+        "missing_scopes": missing,
+        "unexpected_scopes": unexpected,
+        "config_dir": str(RUNNER_GH_CONFIG),
+    }
+
+
+def require_auth() -> dict[str, Any]:
+    status = auth_status()
+    if not status["authenticated"]:
+        raise ValueError("Dedicated GitHub Actions runner credential is not authorized.")
+    if status["missing_scopes"]:
+        raise ValueError(
+            "Dedicated runner credential is missing required scopes: "
+            + ", ".join(status["missing_scopes"])
+        )
+    if status["unexpected_scopes"]:
+        raise ValueError(
+            "Dedicated runner credential has unexpected scopes and was rejected: "
+            + ", ".join(status["unexpected_scopes"])
+        )
+    return status
+
+
+def _validate_repository(full_name: str) -> str:
+    normalized = full_name.strip()
+    if not REPOSITORY_PATTERN.fullmatch(normalized):
+        raise ValueError("Repository must use owner/name format.")
+    return normalized
+
+
+def _managed_project(project: Project) -> None:
+    try:
+        project.path.resolve().relative_to(PROJECTS_ROOT.resolve())
+    except ValueError as exc:
+        raise ValueError("Repository publishing is limited to managed DPSR projects.") from exc
+
+
+def _repository_metadata(project: Project) -> dict[str, Any]:
+    raw = project.metadata.get("repository") or {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def repository_binding(project: Project) -> dict[str, str]:
+    raw = _repository_metadata(project)
+    full_name = str(raw.get("full_name", "")).strip()
+    branch = str(raw.get("branch", "main")).strip() or "main"
+    workflow = str(raw.get("workflow", "")).strip()
+    if full_name:
+        _validate_repository(full_name)
+    return {"full_name": full_name, "branch": branch, "workflow": workflow}
+
+
+def workflow_for(project: Project) -> str:
+    binding = repository_binding(project)
+    if binding["workflow"]:
+        return binding["workflow"]
+    try:
+        return WORKFLOW_BY_PROFILE[project.profile]
+    except KeyError as exc:
+        raise ValueError(f"Profile '{project.profile}' has no GitHub Actions workflow mapping.") from exc
+
+
+def _rewrite_repository_table(path: Path, full_name: str, branch: str, workflow: str) -> None:
+    manifest = path / "dpsr.toml"
+    text = manifest.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    kept: list[str] = []
+    index = 0
+    while index < len(lines):
+        if lines[index].strip() == "[repository]":
+            index += 1
+            while index < len(lines) and not lines[index].lstrip().startswith("["):
+                index += 1
+            continue
+        kept.append(lines[index])
+        index += 1
+    rendered = "\n".join(kept).rstrip() + "\n\n[repository]\n"
+    rendered += f'full_name = "{full_name}"\n'
+    rendered += f'branch = "{branch}"\n'
+    rendered += f'workflow = "{workflow}"\n'
+    manifest.write_text(rendered, encoding="utf-8")
+
+
+def _authenticated_owner() -> str:
+    result = _require_ok("GitHub account lookup", _gh("api", "user", "--jq", ".login", timeout=30))
+    owner = result["stdout"].strip()
+    if not owner or not re.fullmatch(r"[A-Za-z0-9-]+", owner):
+        raise ValueError("Unable to resolve the authenticated GitHub account.")
+    return owner
+
+
+def _repo_exists(full_name: str) -> bool:
+    result = _gh("repo", "view", full_name, "--json", "nameWithOwner", timeout=30)
+    if result["returncode"] == 0:
+        return True
+    detail = _detail(result).lower()
+    if "could not resolve to a repository" in detail or "not found" in detail or "http 404" in detail:
+        return False
+    raise ValueError(f"GitHub repository lookup failed: {_detail(result)}")
+
+
+def _setup_git_credential_helper() -> None:
+    RUNNER_GIT_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+    result = _require_ok(
+        "GitHub git credential setup",
+        _gh("auth", "setup-git", "--hostname", "github.com", timeout=30),
+    )
+    _ = result
+    if RUNNER_GIT_CONFIG.exists():
+        os.chmod(RUNNER_GIT_CONFIG, 0o600)
+
+
+def _ensure_git_repository(project: Project, full_name: str, branch: str) -> None:
+    if not (project.path / ".git").is_dir():
+        _require_ok("git init", _git(project, "init", "-b", branch, timeout=30))
+
+    remote = _git(project, "remote", "get-url", "origin", timeout=10)
+    expected = f"https://github.com/{full_name}.git"
+    if remote["returncode"] == 0:
+        current = remote["stdout"].strip().removesuffix("/")
+        accepted = {
+            expected.removesuffix("/"),
+            f"https://github.com/{full_name}".removesuffix("/"),
+            f"git@github.com:{full_name}.git",
+        }
+        if current not in accepted:
+            raise ValueError(f"Project origin points to a different repository: {current}")
+    else:
+        _require_ok("git remote add", _git(project, "remote", "add", "origin", expected, timeout=10))
+
+    _require_ok("git add", _git(project, "add", "-A", timeout=60))
+    staged = _git(project, "diff", "--cached", "--quiet", timeout=30)
+    if staged["returncode"] == 1:
+        commit = _git(
+            project,
+            "-c",
+            "user.name=DPSR",
+            "-c",
+            "user.email=dpsr@localhost",
+            "commit",
+            "-m",
+            "Initialize DPSR project",
+            timeout=120,
+        )
+        _require_ok("git commit", commit)
+    elif staged["returncode"] != 0:
+        raise ValueError(f"git staged-change check failed: {_detail(staged)}")
+
+    _setup_git_credential_helper()
+    _require_ok("git push", _git(project, "push", "-u", "origin", branch, timeout=600))
+
+
+def publish_project(
+    project: Project,
+    repository: str = "",
+    visibility: str = "private",
+) -> dict[str, Any]:
+    _managed_project(project)
+    require_auth()
+    if visibility not in {"private", "public"}:
+        raise ValueError("Repository visibility must be private or public.")
+    owner = _authenticated_owner()
+    full_name = _validate_repository(repository or f"{owner}/{project.name}")
+    if full_name.split("/", 1)[0].lower() != owner.lower():
+        raise ValueError("Automatic repository creation is limited to the authenticated account.")
+
+    binding = repository_binding(project)
+    branch = binding["branch"] or "main"
+    workflow = workflow_for(project) if project.runner == "github-actions" else binding["workflow"]
+
+    exists = _repo_exists(full_name)
+    if not exists:
+        create_args = ["repo", "create", full_name, f"--{visibility}", "--description", f"DPSR project: {project.name}"]
+        _require_ok("GitHub repository creation", _gh(*create_args, timeout=60))
+    elif binding["full_name"] and binding["full_name"].lower() != full_name.lower():
+        raise ValueError("Project is already bound to a different GitHub repository.")
+
+    _rewrite_repository_table(project.path, full_name, branch, workflow)
+    bound = register_project(project.path)
+    _ensure_git_repository(bound, full_name, branch)
+    return {
+        "name": bound.name,
+        "repository": full_name,
+        "branch": branch,
+        "workflow": workflow,
+        "visibility": visibility,
+        "created_repository": not exists,
+        "published": True,
+    }
+
+
+def dispatch(project: Project, command_name: str) -> dict[str, Any]:
+    require_auth()
+    binding = repository_binding(project)
+    full_name = binding["full_name"]
+    if not full_name:
+        raise ValueError("Project is not published to a GitHub repository.")
+    workflow = workflow_for(project)
+    branch = binding["branch"] or "main"
+    started = _utc()
+    _require_ok(
+        "GitHub Actions dispatch",
+        _gh("workflow", "run", workflow, "--repo", full_name, "--ref", branch, timeout=60),
+    )
+
+    run_id: int | None = None
+    run_url = ""
+    run_status = "submitted"
+    for _attempt in range(8):
+        result = _gh(
+            "run",
+            "list",
+            "--repo",
+            full_name,
+            "--workflow",
+            workflow,
+            "--event",
+            "workflow_dispatch",
+            "--branch",
+            branch,
+            "--limit",
+            "5",
+            "--json",
+            "databaseId,createdAt,status,conclusion,url",
+            timeout=30,
+        )
+        if result["returncode"] == 0:
+            try:
+                rows = json.loads(result["stdout"] or "[]")
+            except json.JSONDecodeError:
+                rows = []
+            if rows:
+                row = rows[0]
+                run_id = int(row.get("databaseId") or 0) or None
+                run_url = str(row.get("url") or "")
+                run_status = str(row.get("status") or "submitted")
+                break
+        time.sleep(2)
+
+    return {
+        "provider": "github-actions",
+        "repository": full_name,
+        "workflow": workflow,
+        "ref": branch,
+        "command": command_name,
+        "dispatched_at": started,
+        "run_id": run_id,
+        "url": run_url,
+        "status": run_status,
+    }
+
+
+def refresh(external: dict[str, Any]) -> dict[str, Any]:
+    require_auth()
+    repository = _validate_repository(str(external.get("repository", "")))
+    run_id = int(external.get("run_id") or 0)
+    if run_id <= 0:
+        raise ValueError("External job has no GitHub Actions run id.")
+    result = _require_ok(
+        "GitHub Actions run lookup",
+        _gh(
+            "run",
+            "view",
+            str(run_id),
+            "--repo",
+            repository,
+            "--json",
+            "databaseId,status,conclusion,url,createdAt,updatedAt,workflowName,headBranch",
+            timeout=30,
+        ),
+    )
+    try:
+        row = json.loads(result["stdout"])
+    except json.JSONDecodeError as exc:
+        raise ValueError("GitHub Actions returned invalid run metadata.") from exc
+    status = str(row.get("status") or "unknown")
+    conclusion = str(row.get("conclusion") or "")
+    return {
+        **external,
+        "run_id": int(row.get("databaseId") or run_id),
+        "status": status,
+        "conclusion": conclusion,
+        "url": str(row.get("url") or external.get("url") or ""),
+        "updated_at": str(row.get("updatedAt") or ""),
+        "workflow_name": str(row.get("workflowName") or ""),
+        "head_branch": str(row.get("headBranch") or ""),
+    }
+
+
+def external_state(external: dict[str, Any]) -> tuple[str, int | None]:
+    status = str(external.get("status") or "").lower()
+    conclusion = str(external.get("conclusion") or "").lower()
+    if status in ACTIVE_RUN_STATES or status == "submitted":
+        return "running", None
+    if status == "completed":
+        if conclusion == "success":
+            return "succeeded", 0
+        return "failed", 1
+    return "running", None

--- a/security_lab/platform/jobs.py
+++ b/security_lab/platform/jobs.py
@@ -6,12 +6,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .github_actions import dispatch as dispatch_github_actions
+from .github_actions import external_state, refresh as refresh_github_actions
 from .paths import STATE_ROOT
 from .registry import get_project
 from .runners import get_runner
 
 JOBS_ROOT = STATE_ROOT / "jobs"
-VALID_STATES = {"queued", "running", "succeeded", "failed"}
+VALID_STATES = {"queued", "running", "submitted", "succeeded", "failed"}
+ACTIVE_STATES = {"queued", "running", "submitted"}
 
 
 def _utc() -> str:
@@ -32,11 +35,12 @@ def _write(job: dict[str, Any]) -> None:
     temp.replace(path)
 
 
-def create_job(project: str, command: str) -> dict[str, Any]:
+def create_job(project: str, command: str, runner: str = "local") -> dict[str, Any]:
     job = {
         "id": f"job-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{secrets.token_hex(3)}",
         "project": project,
         "command": command,
+        "runner": runner,
         "state": "queued",
         "created_at": _utc(),
         "started_at": None,
@@ -44,6 +48,7 @@ def create_job(project: str, command: str) -> dict[str, Any]:
         "returncode": None,
         "stdout": "",
         "stderr": "",
+        "external": None,
     }
     _write(job)
     return job
@@ -68,6 +73,17 @@ def list_jobs(limit: int = 50) -> list[dict[str, Any]]:
     return rows
 
 
+def _finish_external(job: dict[str, Any], external: dict[str, Any]) -> dict[str, Any]:
+    state, returncode = external_state(external)
+    job["external"] = external
+    job["state"] = state
+    job["returncode"] = returncode
+    if state in {"succeeded", "failed"}:
+        job["finished_at"] = _utc()
+    _write(job)
+    return job
+
+
 def run_job(project_name: str, command_name: str) -> dict[str, Any]:
     project = get_project(project_name)
     try:
@@ -76,10 +92,24 @@ def run_job(project_name: str, command_name: str) -> dict[str, Any]:
         available = ", ".join(sorted(project.commands)) or "none"
         raise ValueError(f"Project '{project_name}' has no command '{command_name}'. Available: {available}") from exc
 
-    job = create_job(project_name, command_name)
+    job = create_job(project_name, command_name, project.runner)
     job["state"] = "running"
     job["started_at"] = _utc()
     _write(job)
+
+    if project.runner == "github-actions":
+        try:
+            external = dispatch_github_actions(project, command_name)
+            job["state"] = "submitted"
+            _write(job)
+            return _finish_external(job, external)
+        except Exception as exc:
+            job["returncode"] = 1
+            job["stderr"] = str(exc)
+            job["state"] = "failed"
+            job["finished_at"] = _utc()
+            _write(job)
+            return job
 
     try:
         result = get_runner(project.runner).run(project, command)
@@ -94,3 +124,27 @@ def run_job(project_name: str, command_name: str) -> dict[str, Any]:
     job["finished_at"] = _utc()
     _write(job)
     return job
+
+
+def refresh_job(job_id: str) -> dict[str, Any]:
+    job = get_job(job_id)
+    external = job.get("external")
+    if job.get("runner") != "github-actions" or not isinstance(external, dict):
+        return job
+    if job.get("state") not in ACTIVE_STATES:
+        return job
+    try:
+        refreshed = refresh_github_actions(external)
+        return _finish_external(job, refreshed)
+    except Exception as exc:
+        job["stderr"] = str(exc)
+        _write(job)
+        return job
+
+
+def refresh_pending_jobs(limit: int = 20) -> list[dict[str, Any]]:
+    refreshed: list[dict[str, Any]] = []
+    for job in list_jobs(max(1, min(limit, 100))):
+        if job.get("runner") == "github-actions" and job.get("state") in ACTIVE_STATES:
+            refreshed.append(refresh_job(str(job["id"])))
+    return refreshed

--- a/security_lab/platform/models.py
+++ b/security_lab/platform/models.py
@@ -67,6 +67,7 @@ def load_project_manifest(path: Path) -> Project:
 
     project = data.get("project") or {}
     runner = data.get("runner") or {}
+    repository = data.get("repository") or {}
     raw_commands = data.get("commands") or {}
     services = data.get("services") or {}
 
@@ -75,6 +76,8 @@ def load_project_manifest(path: Path) -> Project:
     runner_type = str(runner.get("type", "local")).strip() or "local"
     if not name:
         raise ValueError(f"Project manifest at {manifest_path} has no project.name.")
+    if not isinstance(repository, dict):
+        raise ValueError("Project repository metadata must be a TOML table.")
 
     commands = {key: CommandSpec.from_value(value) for key, value in raw_commands.items()}
     normalized_services: dict[str, int] = {}
@@ -91,5 +94,5 @@ def load_project_manifest(path: Path) -> Project:
         runner=runner_type,
         commands=commands,
         services=normalized_services,
-        metadata={"project": project, "runner": runner},
+        metadata={"project": project, "runner": runner, "repository": repository},
     )

--- a/security_lab/remote_agent_ext.py
+++ b/security_lab/remote_agent_ext.py
@@ -113,6 +113,10 @@ class TaskRunner(base.TaskRunner):
                     "supervisor-restart": base.TaskSpec(("bash", f"{root}/admin/control-plane-supervisor", "restart"), 30),
                     "bridge-credential-status": base.TaskSpec(("bash", f"{root}/admin/bridge-credential-status"), 30),
                     "bridge-reload": base.TaskSpec(("bash", f"{root}/admin/bridge-reload"), 30),
+                    "runner-auth-start": base.TaskSpec(("bash", f"{root}/admin/runner-auth-control", "start"), 30),
+                    "runner-auth-status": base.TaskSpec(("bash", f"{root}/admin/runner-auth-control", "status"), 30),
+                    "runner-auth-stop": base.TaskSpec(("bash", f"{root}/admin/runner-auth-control", "stop"), 30),
+                    "runner-credential-status": base.TaskSpec(("bash", f"{root}/admin/runner-credential-status"), 30),
                 }
             )
 

--- a/tests/test_external_runner.py
+++ b/tests/test_external_runner.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from security_lab.platform import github_actions, jobs, registry
+from security_lab.platform.models import CommandSpec, Project, load_project_manifest
+
+
+class GitHubActionsRunnerTests(unittest.TestCase):
+    def test_auth_status_accepts_dedicated_repo_workflow_scopes(self) -> None:
+        result = {
+            "returncode": 0,
+            "stdout": "",
+            "stderr": "Logged in to github.com\n  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'\n",
+        }
+        with mock.patch.object(github_actions, "_gh", return_value=result):
+            status = github_actions.auth_status()
+        self.assertTrue(status["authenticated"])
+        self.assertTrue(status["safe"])
+        self.assertEqual(status["missing_scopes"], [])
+        self.assertEqual(status["unexpected_scopes"], [])
+
+    def test_auth_status_rejects_codespace_or_other_unexpected_scope(self) -> None:
+        result = {
+            "returncode": 0,
+            "stdout": "",
+            "stderr": "Logged in to github.com\n  - Token scopes: 'codespace', 'repo', 'workflow'\n",
+        }
+        with mock.patch.object(github_actions, "_gh", return_value=result):
+            status = github_actions.auth_status()
+        self.assertFalse(status["safe"])
+        self.assertEqual(status["unexpected_scopes"], ["codespace"])
+
+    def test_repository_table_roundtrip_is_structured_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            (root / "dpsr.toml").write_text(
+                """
+[project]
+name = "demo"
+profile = "ios"
+[runner]
+type = "github-actions"
+[commands.build]
+argv = ["xcodebuild", "build"]
+cwd = "app"
+timeout = 3600
+""".strip() + "\n",
+                encoding="utf-8",
+            )
+            github_actions._rewrite_repository_table(root, "octocat/demo", "main", "ios.yml")
+            project = load_project_manifest(root)
+        self.assertEqual(project.metadata["repository"]["full_name"], "octocat/demo")
+        self.assertEqual(project.metadata["repository"]["branch"], "main")
+        self.assertEqual(project.metadata["repository"]["workflow"], "ios.yml")
+
+    def test_publish_refuses_unmanaged_project(self) -> None:
+        project = Project(
+            name="demo",
+            path=Path("/tmp/unmanaged-dpsr-project"),
+            profile="ios",
+            runner="github-actions",
+            commands={"build": CommandSpec(("xcodebuild", "build"), cwd="app")},
+            services={},
+            metadata={"repository": {}},
+        )
+        with mock.patch.object(github_actions, "PROJECTS_ROOT", Path("/workspaces/dpsr-projects")):
+            with self.assertRaisesRegex(ValueError, "managed DPSR projects"):
+                github_actions.publish_project(project)
+
+    def test_publish_creates_repo_binds_manifest_and_pushes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            base = Path(temp)
+            managed = base / "managed"
+            state = base / "state"
+            root = managed / "demo-ios"
+            (root / "app").mkdir(parents=True)
+            (root / "dpsr.toml").write_text(
+                """
+[project]
+name = "demo-ios"
+profile = "ios"
+[runner]
+type = "github-actions"
+[commands.build]
+argv = ["xcodebuild", "build"]
+cwd = "app"
+timeout = 3600
+""".strip() + "\n",
+                encoding="utf-8",
+            )
+            project = load_project_manifest(root)
+            with (
+                mock.patch.object(github_actions, "PROJECTS_ROOT", managed),
+                mock.patch.object(github_actions, "require_auth", return_value={"safe": True}),
+                mock.patch.object(github_actions, "_authenticated_owner", return_value="octocat"),
+                mock.patch.object(github_actions, "_repo_exists", return_value=False),
+                mock.patch.object(github_actions, "_gh", return_value={"returncode": 0, "stdout": "", "stderr": ""}) as gh_mock,
+                mock.patch.object(github_actions, "_ensure_git_repository") as push_mock,
+                mock.patch.object(registry, "STATE_ROOT", state),
+                mock.patch.object(registry, "REGISTRY_PATH", state / "projects.json"),
+            ):
+                published = github_actions.publish_project(project)
+
+            self.assertEqual(published["repository"], "octocat/demo-ios")
+            self.assertTrue(published["created_repository"])
+            rebound = load_project_manifest(root)
+            self.assertEqual(rebound.metadata["repository"]["workflow"], "ios.yml")
+            push_mock.assert_called_once()
+            self.assertEqual(gh_mock.call_args.args[:3], ("repo", "create", "octocat/demo-ios"))
+
+    def test_dispatch_records_remote_run_identity(self) -> None:
+        project = Project(
+            name="demo",
+            path=Path("/tmp/demo"),
+            profile="android",
+            runner="github-actions",
+            commands={"build": CommandSpec(("./gradlew", "assembleDebug"), cwd="app")},
+            services={},
+            metadata={
+                "repository": {
+                    "full_name": "octocat/demo",
+                    "branch": "main",
+                    "workflow": "android.yml",
+                }
+            },
+        )
+        run_list = json.dumps([
+            {
+                "databaseId": 12345,
+                "createdAt": "2026-08-24T08:00:00Z",
+                "status": "queued",
+                "conclusion": "",
+                "url": "https://github.com/octocat/demo/actions/runs/12345",
+            }
+        ])
+        responses = [
+            {"returncode": 0, "stdout": "", "stderr": ""},
+            {"returncode": 0, "stdout": run_list, "stderr": ""},
+        ]
+        with (
+            mock.patch.object(github_actions, "require_auth", return_value={"safe": True}),
+            mock.patch.object(github_actions, "_gh", side_effect=responses),
+        ):
+            external = github_actions.dispatch(project, "build")
+        self.assertEqual(external["provider"], "github-actions")
+        self.assertEqual(external["run_id"], 12345)
+        self.assertEqual(external["workflow"], "android.yml")
+        self.assertEqual(external["status"], "queued")
+
+    def test_external_job_dispatch_and_refresh_roundtrip(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            base = Path(temp)
+            root = base / "project"
+            state = base / "state"
+            (root / "app").mkdir(parents=True)
+            (root / "dpsr.toml").write_text(
+                """
+[project]
+name = "remote-demo"
+profile = "ios"
+[runner]
+type = "github-actions"
+[repository]
+full_name = "octocat/remote-demo"
+branch = "main"
+workflow = "ios.yml"
+[commands.build]
+argv = ["xcodebuild", "build"]
+cwd = "app"
+timeout = 3600
+""".strip() + "\n",
+                encoding="utf-8",
+            )
+            external = {
+                "provider": "github-actions",
+                "repository": "octocat/remote-demo",
+                "workflow": "ios.yml",
+                "ref": "main",
+                "command": "build",
+                "run_id": 44,
+                "url": "https://github.com/octocat/remote-demo/actions/runs/44",
+                "status": "queued",
+            }
+            completed = {**external, "status": "completed", "conclusion": "success"}
+            with (
+                mock.patch.object(registry, "STATE_ROOT", state),
+                mock.patch.object(registry, "REGISTRY_PATH", state / "projects.json"),
+                mock.patch.object(jobs, "STATE_ROOT", state),
+                mock.patch.object(jobs, "JOBS_ROOT", state / "jobs"),
+                mock.patch.object(jobs, "dispatch_github_actions", return_value=external),
+                mock.patch.object(jobs, "refresh_github_actions", return_value=completed),
+            ):
+                registry.register_project(root)
+                job = jobs.run_job("remote-demo", "build")
+                self.assertEqual(job["state"], "running")
+                self.assertEqual(job["runner"], "github-actions")
+                self.assertEqual(job["external"]["run_id"], 44)
+                refreshed = jobs.refresh_job(job["id"])
+
+            self.assertEqual(refreshed["state"], "succeeded")
+            self.assertEqual(refreshed["returncode"], 0)
+            self.assertIsNotNone(refreshed["finished_at"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the external execution layer that turns generated mobile workflows into managed DPSR jobs.

Credential separation:
- dedicated GitHub Actions runner credential, separate from both recovery bridge and Codespaces lifecycle credentials
- persistent isolated GitHub CLI config under `/workspaces/.dpsr/runner-gh`
- requires `repo` + `workflow`; rejects unexpected scopes such as `codespace`
- authorization controls live under `admin/` and are exposed only through the owner-authenticated recovery bridge

Repository publishing:
- managed-project-only publish boundary
- private repositories by default, optional public visibility
- repository/branch/workflow binding stored in `dpsr.toml`
- runner-specific Git credential configuration; no token embedded in remotes
- automatic initial commit/push after binding

External jobs:
- dispatch generated GitHub Actions workflows by profile
- persist Actions run ID, URL, status, and provider metadata in the normal DPSR job store
- refresh remote runs into the same running/succeeded/failed lifecycle used by local jobs
- CLI controls for publish, runner status, and job refresh

Includes regression coverage for scope rejection, managed-root boundaries, repository binding, publishing handoff, workflow dispatch, and external-job refresh.