### PR TITLE
Platform v2: use Actions REST API for delayed run discovery

### DIFF
--- a/security_lab/platform/jobs.py
+++ b/security_lab/platform/jobs.py
@@ -5,6 +5,7 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from . import github_actions
 from .github_actions import dispatch as dispatch_github_actions
@@ -121,42 +122,31 @@ def _discover_github_actions_run(job: dict[str, Any], external: dict[str, Any]) 
     upper = dispatched + timedelta(minutes=DISCOVERY_WINDOW_MINUTES)
     excluded = _claimed_external_run_ids(str(job.get("id") or ""))
 
-    result = github_actions._gh(
-        "run",
-        "list",
-        "--repo",
-        repository,
-        "--workflow",
-        workflow,
-        "--event",
-        "workflow_dispatch",
-        "--branch",
-        branch,
-        "--limit",
-        "20",
-        "--json",
-        "databaseId,createdAt,status,conclusion,url",
-        timeout=30,
+    endpoint = (
+        f"repos/{repository}/actions/workflows/{quote(workflow, safe='')}/runs"
+        f"?event=workflow_dispatch&branch={quote(branch, safe='')}&per_page=20"
     )
+    result = github_actions._gh("api", endpoint, timeout=30)
     if result["returncode"] != 0:
         raise ValueError(f"GitHub Actions run discovery failed: {github_actions._detail(result)}")
     try:
-        rows = json.loads(result["stdout"] or "[]")
+        payload = json.loads(result["stdout"] or "{}")
     except json.JSONDecodeError as exc:
         raise ValueError("GitHub Actions returned invalid run-list metadata.") from exc
+    rows = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
 
     candidates: list[tuple[datetime, dict[str, Any]]] = []
     for row in rows if isinstance(rows, list) else []:
         if not isinstance(row, dict):
             continue
         try:
-            run_id = int(row.get("databaseId") or 0)
+            run_id = int(row.get("id") or 0)
         except (TypeError, ValueError):
             continue
         if run_id <= 0 or run_id in excluded:
             continue
         try:
-            created = _parse_utc(str(row.get("createdAt") or ""))
+            created = _parse_utc(str(row.get("created_at") or ""))
         except ValueError:
             continue
         if lower <= created <= upper:
@@ -168,10 +158,10 @@ def _discover_github_actions_run(job: dict[str, Any], external: dict[str, Any]) 
     _created, row = min(candidates, key=lambda item: item[0])
     return {
         **external,
-        "run_id": int(row.get("databaseId") or 0),
+        "run_id": int(row.get("id") or 0),
         "status": str(row.get("status") or external.get("status") or "submitted"),
         "conclusion": str(row.get("conclusion") or external.get("conclusion") or ""),
-        "url": str(row.get("url") or external.get("url") or ""),
+        "url": str(row.get("html_url") or external.get("url") or ""),
         "discovered_at": _utc(),
     }
 

--- a/tests/test_runner_discovery.py
+++ b/tests/test_runner_discovery.py
@@ -23,21 +23,24 @@ class RunnerDiscoveryTests(unittest.TestCase):
             "url": "",
         }
         rows = [
-            {"databaseId": 1, "createdAt": "2026-08-24T08:40:30Z", "status": "completed", "conclusion": "success", "url": "old"},
-            {"databaseId": 2, "createdAt": "2026-08-24T08:40:55Z", "status": "queued", "conclusion": "", "url": "claimed"},
-            {"databaseId": 3, "createdAt": "2026-08-24T08:41:00Z", "status": "in_progress", "conclusion": "", "url": "selected"},
+            {"id": 1, "created_at": "2026-08-24T08:40:30Z", "status": "completed", "conclusion": "success", "html_url": "old"},
+            {"id": 2, "created_at": "2026-08-24T08:40:55Z", "status": "queued", "conclusion": "", "html_url": "claimed"},
+            {"id": 3, "created_at": "2026-08-24T08:41:00Z", "status": "in_progress", "conclusion": "", "html_url": "selected"},
         ]
         job = {"id": "job-current"}
-        result = {"returncode": 0, "stdout": json.dumps(rows), "stderr": ""}
+        result = {"returncode": 0, "stdout": json.dumps({"workflow_runs": rows}), "stderr": ""}
         with (
             mock.patch.object(jobs.github_actions, "require_auth", return_value={"safe": True}),
-            mock.patch.object(jobs.github_actions, "_gh", return_value=result),
+            mock.patch.object(jobs.github_actions, "_gh", return_value=result) as gh_mock,
             mock.patch.object(jobs, "_claimed_external_run_ids", return_value={2}),
         ):
             discovered = jobs._discover_github_actions_run(job, external)
         self.assertEqual(discovered["run_id"], 3)
         self.assertEqual(discovered["url"], "selected")
         self.assertEqual(discovered["status"], "in_progress")
+        self.assertEqual(gh_mock.call_args.args[0], "api")
+        self.assertIn("event=workflow_dispatch", gh_mock.call_args.args[1])
+        self.assertIn("branch=main", gh_mock.call_args.args[1])
 
     def test_refresh_recovers_missing_run_id_before_status_lookup(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
Replaces `gh run list --event` in delayed external-job recovery because the Codespace GitHub CLI version does not support that flag.

- queries the workflow-runs REST endpoint through the isolated runner credential
- filters `workflow_dispatch` and branch server-side
- preserves timestamp-window and already-claimed run protections
- updates regression coverage to the REST payload shape and verifies the event/branch filters