### PR TITLE
Platform v2: repair Android/iOS generated builds

### DIFF
--- a/security_lab/platform/api.py
+++ b/security_lab/platform/api.py
@@ -6,7 +6,7 @@ from .github_actions import auth_status as github_actions_auth_status
 from .github_actions import publish_project as publish_github_project
 from .github_actions import repository_binding
 from .jobs import list_jobs, refresh_job, refresh_pending_jobs, run_job
-from .mobile import MOBILE_PROFILES, init_mobile_project
+from .mobile import MOBILE_PROFILES, init_mobile_project, refresh_mobile_build_files
 from .models import Profile, Project
 from .profiles import get_profile, load_profiles
 from .registry import delete_managed_project, get_project, list_projects
@@ -98,6 +98,11 @@ def create_project(name: str, profile_name: str) -> dict[str, Any]:
     if profile_name in MOBILE_PROFILES:
         return project_row(init_mobile_project(name, profile_name))
     return project_row(init_project(name, profile_name))
+
+
+def refresh_project_template(name: str) -> dict[str, Any]:
+    project_model = get_project(name)
+    return project_row(refresh_mobile_build_files(project_model))
 
 
 def publish_project(

--- a/security_lab/platform/cli.py
+++ b/security_lab/platform/cli.py
@@ -10,7 +10,7 @@ from .github_actions import auth_status as github_actions_auth_status
 from .github_actions import publish_project as publish_github_project
 from .github_actions import repository_binding
 from .jobs import list_jobs, refresh_job, run_job
-from .mobile import MOBILE_PROFILES, init_mobile_project
+from .mobile import MOBILE_PROFILES, init_mobile_project, refresh_mobile_build_files
 from .profiles import get_profile, load_profiles
 from .registry import delete_managed_project, get_project, list_projects, register_project, unregister_project
 from .runners import RUNNERS
@@ -108,6 +108,10 @@ def cmd_project(args: argparse.Namespace) -> int:
             project = init_project(args.name, args.profile, target)
         print(json.dumps(_project_row(project), indent=2, sort_keys=True))
         return 0
+    if action == "refresh-template":
+        project = refresh_mobile_build_files(get_project(args.name))
+        print(json.dumps(_project_row(project), indent=2, sort_keys=True))
+        return 0
     if action == "publish":
         project = get_project(args.name)
         result = publish_github_project(project, args.repo or "", args.visibility)
@@ -185,6 +189,8 @@ def build_parser() -> argparse.ArgumentParser:
     project_init.add_argument("name")
     project_init.add_argument("--profile", required=True)
     project_init.add_argument("--path")
+    project_refresh = project_sub.add_parser("refresh-template")
+    project_refresh.add_argument("name")
     project_publish = project_sub.add_parser("publish")
     project_publish.add_argument("name")
     project_publish.add_argument("--repo")

--- a/security_lab/platform/github_actions.py
+++ b/security_lab/platform/github_actions.py
@@ -4,11 +4,11 @@ import json
 import os
 import re
 import subprocess  # nosec B404
-import tempfile
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
+from urllib.parse import quote
 
 from .models import Project
 from .paths import PERSISTENT_ROOT, PROJECTS_ROOT
@@ -30,10 +30,27 @@ WORKFLOW_BY_PROFILE = {
     "ios": "ios.yml",
 }
 ACTIVE_RUN_STATES = frozenset({"queued", "in_progress", "pending", "requested", "waiting"})
+RUN_DISCOVERY_SKEW_SECONDS = 5
+RUN_DISCOVERY_WINDOW_MINUTES = 15
 
 
 def _utc() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_utc(value: str) -> datetime:
+    text = value.strip()
+    if not text:
+        raise ValueError("Missing GitHub Actions dispatch timestamp.")
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError("Invalid GitHub Actions timestamp.") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _runner_env() -> dict[str, str]:
@@ -210,17 +227,17 @@ def _repo_exists(full_name: str) -> bool:
 
 def _setup_git_credential_helper() -> None:
     RUNNER_GIT_CONFIG.parent.mkdir(parents=True, exist_ok=True)
-    result = _require_ok(
+    _require_ok(
         "GitHub git credential setup",
         _gh("auth", "setup-git", "--hostname", "github.com", timeout=30),
     )
-    _ = result
     if RUNNER_GIT_CONFIG.exists():
         os.chmod(RUNNER_GIT_CONFIG, 0o600)
 
 
 def _ensure_git_repository(project: Project, full_name: str, branch: str) -> None:
-    if not (project.path / ".git").is_dir():
+    new_repository = not (project.path / ".git").is_dir()
+    if new_repository:
         _require_ok("git init", _git(project, "init", "-b", branch, timeout=30))
 
     remote = _git(project, "remote", "get-url", "origin", timeout=10)
@@ -248,7 +265,7 @@ def _ensure_git_repository(project: Project, full_name: str, branch: str) -> Non
             "user.email=dpsr@localhost",
             "commit",
             "-m",
-            "Initialize DPSR project",
+            "Initialize DPSR project" if new_repository else "Update DPSR project",
             timeout=120,
         )
         _require_ok("git commit", commit)
@@ -298,6 +315,58 @@ def publish_project(
     }
 
 
+def discover_dispatched_run(
+    repository: str,
+    workflow: str,
+    branch: str,
+    dispatched_at: str,
+    exclude_run_ids: Iterable[int] = (),
+) -> dict[str, Any] | None:
+    full_name = _validate_repository(repository)
+    dispatched = _parse_utc(dispatched_at)
+    lower = dispatched - timedelta(seconds=RUN_DISCOVERY_SKEW_SECONDS)
+    upper = dispatched + timedelta(minutes=RUN_DISCOVERY_WINDOW_MINUTES)
+    excluded = {int(value) for value in exclude_run_ids if int(value) > 0}
+    endpoint = (
+        f"repos/{full_name}/actions/workflows/{quote(workflow, safe='')}/runs"
+        f"?event=workflow_dispatch&branch={quote(branch, safe='')}&per_page=20"
+    )
+    result = _gh("api", endpoint, timeout=30)
+    if result["returncode"] != 0:
+        raise ValueError(f"GitHub Actions run discovery failed: {_detail(result)}")
+    try:
+        payload = json.loads(result["stdout"] or "{}")
+    except json.JSONDecodeError as exc:
+        raise ValueError("GitHub Actions returned invalid run-list metadata.") from exc
+    rows = payload.get("workflow_runs", []) if isinstance(payload, dict) else []
+    candidates: list[tuple[datetime, dict[str, Any]]] = []
+    for row in rows if isinstance(rows, list) else []:
+        if not isinstance(row, dict):
+            continue
+        try:
+            run_id = int(row.get("id") or 0)
+        except (TypeError, ValueError):
+            continue
+        if run_id <= 0 or run_id in excluded:
+            continue
+        try:
+            created = _parse_utc(str(row.get("created_at") or ""))
+        except ValueError:
+            continue
+        if lower <= created <= upper:
+            candidates.append((created, row))
+    if not candidates:
+        return None
+    _created, row = min(candidates, key=lambda item: item[0])
+    return {
+        "run_id": int(row.get("id") or 0),
+        "status": str(row.get("status") or "submitted"),
+        "conclusion": str(row.get("conclusion") or ""),
+        "url": str(row.get("html_url") or ""),
+        "created_at": str(row.get("created_at") or ""),
+    }
+
+
 def dispatch(project: Project, command_name: str) -> dict[str, Any]:
     require_auth()
     binding = repository_binding(project)
@@ -312,38 +381,11 @@ def dispatch(project: Project, command_name: str) -> dict[str, Any]:
         _gh("workflow", "run", workflow, "--repo", full_name, "--ref", branch, timeout=60),
     )
 
-    run_id: int | None = None
-    run_url = ""
-    run_status = "submitted"
+    discovered: dict[str, Any] | None = None
     for _attempt in range(8):
-        result = _gh(
-            "run",
-            "list",
-            "--repo",
-            full_name,
-            "--workflow",
-            workflow,
-            "--event",
-            "workflow_dispatch",
-            "--branch",
-            branch,
-            "--limit",
-            "5",
-            "--json",
-            "databaseId,createdAt,status,conclusion,url",
-            timeout=30,
-        )
-        if result["returncode"] == 0:
-            try:
-                rows = json.loads(result["stdout"] or "[]")
-            except json.JSONDecodeError:
-                rows = []
-            if rows:
-                row = rows[0]
-                run_id = int(row.get("databaseId") or 0) or None
-                run_url = str(row.get("url") or "")
-                run_status = str(row.get("status") or "submitted")
-                break
+        discovered = discover_dispatched_run(full_name, workflow, branch, started)
+        if discovered is not None:
+            break
         time.sleep(2)
 
     return {
@@ -353,9 +395,10 @@ def dispatch(project: Project, command_name: str) -> dict[str, Any]:
         "ref": branch,
         "command": command_name,
         "dispatched_at": started,
-        "run_id": run_id,
-        "url": run_url,
-        "status": run_status,
+        "run_id": discovered["run_id"] if discovered else None,
+        "url": discovered["url"] if discovered else "",
+        "status": discovered["status"] if discovered else "submitted",
+        "conclusion": discovered["conclusion"] if discovered else "",
     }
 
 

--- a/security_lab/platform/mobile.py
+++ b/security_lab/platform/mobile.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from security_lab.common import run_command
 
-from .models import CommandSpec, Profile
+from .models import CommandSpec, Profile, Project
 from .paths import PERSISTENT_ROOT, PROJECTS_ROOT
 from .profiles import get_profile
 from .registry import register_project
@@ -19,7 +19,8 @@ TOOLCHAINS_ROOT = PERSISTENT_ROOT / ".dpsr" / "toolchains"
 FLUTTER_ROOT = TOOLCHAINS_ROOT / "flutter"
 ANDROID_AGP = "9.3.0"
 ANDROID_GRADLE = "9.5.0"
-ANDROID_COMPILE_SDK = 37
+ANDROID_COMPILE_SDK = 36
+ANDROID_BUILD_TOOLS = "36.0.0"
 
 
 def _toml_string(value: str) -> str:
@@ -142,7 +143,7 @@ def _package_suffix(name: str) -> str:
 
 def _managed_destination(destination: Path) -> bool:
     try:
-        destination.relative_to(PROJECTS_ROOT.resolve())
+        destination.resolve().relative_to(PROJECTS_ROOT.resolve())
         return True
     except ValueError:
         return False
@@ -255,16 +256,10 @@ def _provision_react_native(destination: Path, name: str, profile: Profile) -> P
     return profile
 
 
-def _write_android_project(destination: Path, name: str) -> None:
+def _write_android_build_config(destination: Path, name: str) -> None:
     app = destination / "app"
-    source = app / "app" / "src" / "main"
-    package_suffix = _package_suffix(name)
-    package = f"com.digitalparagon.{package_suffix}"
-    package_path = source / "java" / "com" / "digitalparagon" / package_suffix
-    values = source / "res" / "values"
-    package_path.mkdir(parents=True, exist_ok=True)
-    values.mkdir(parents=True, exist_ok=True)
-
+    package = f"com.digitalparagon.{_package_suffix(name)}"
+    app.mkdir(parents=True, exist_ok=True)
     (app / "settings.gradle.kts").write_text(
         'pluginManagement { repositories { google(); mavenCentral(); gradlePluginPortal() } }\n'
         'dependencyResolutionManagement { repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS); repositories { google(); mavenCentral() } }\n'
@@ -297,6 +292,18 @@ def _write_android_project(destination: Path, name: str) -> None:
         "}\n",
         encoding="utf-8",
     )
+    (app / "gradle.properties").write_text("org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8\n", encoding="utf-8")
+    (app / ".gitignore").write_text(".gradle/\nlocal.properties\nbuild/\napp/build/\n", encoding="utf-8")
+
+
+def _write_android_source(destination: Path, name: str) -> None:
+    source = destination / "app" / "app" / "src" / "main"
+    package_suffix = _package_suffix(name)
+    package = f"com.digitalparagon.{package_suffix}"
+    package_path = source / "java" / "com" / "digitalparagon" / package_suffix
+    values = source / "res" / "values"
+    package_path.mkdir(parents=True, exist_ok=True)
+    values.mkdir(parents=True, exist_ok=True)
     (source / "AndroidManifest.xml").write_text(
         '<manifest xmlns:android="http://schemas.android.com/apk/res/android">\n'
         '    <application android:theme="@style/AppTheme" android:label="@string/app_name">\n'
@@ -311,7 +318,8 @@ def _write_android_project(destination: Path, name: str) -> None:
         encoding="utf-8",
     )
     (values / "strings.xml").write_text(
-        f'<resources><string name="app_name">{_pascal_name(name)}</string></resources>\n', encoding="utf-8"
+        f'<resources><string name="app_name">{_pascal_name(name)}</string></resources>\n',
+        encoding="utf-8",
     )
     (values / "styles.xml").write_text(
         '<resources><style name="AppTheme" parent="android:style/Theme.Material.Light.NoActionBar" /></resources>\n',
@@ -333,8 +341,6 @@ def _write_android_project(destination: Path, name: str) -> None:
         "}\n",
         encoding="utf-8",
     )
-    (app / "gradle.properties").write_text("org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8\n", encoding="utf-8")
-    (app / ".gitignore").write_text(".gradle/\nlocal.properties\nbuild/\napp/build/\n", encoding="utf-8")
 
 
 def _write_android_workflow(destination: Path) -> None:
@@ -359,7 +365,7 @@ def _write_android_workflow(destination: Path) -> None:
         "      - uses: gradle/actions/setup-gradle@v4\n"
         "        with:\n"
         f"          gradle-version: '{ANDROID_GRADLE}'\n"
-        f"      - run: sdkmanager 'platforms;android-{ANDROID_COMPILE_SDK}' 'build-tools;36.0.0'\n"
+        f"      - run: sdkmanager 'platforms;android-{ANDROID_COMPILE_SDK}' 'build-tools;{ANDROID_BUILD_TOOLS}'\n"
         "      - run: gradle lint test assembleDebug\n"
         "        working-directory: app\n",
         encoding="utf-8",
@@ -368,17 +374,15 @@ def _write_android_workflow(destination: Path) -> None:
 
 def _provision_android(destination: Path, name: str, profile: Profile) -> Profile:
     destination.mkdir(parents=True, exist_ok=True)
-    _write_android_project(destination, name)
+    _write_android_build_config(destination, name)
+    _write_android_source(destination, name)
     _write_android_workflow(destination)
     return profile
 
 
-def _write_ios_project(destination: Path, name: str) -> None:
-    app = destination / "app"
-    sources = app / "Sources"
+def _write_ios_source(destination: Path) -> None:
+    sources = destination / "app" / "Sources"
     sources.mkdir(parents=True, exist_ok=True)
-    app_name = _pascal_name(name)
-    bundle = f"com.digitalparagon.{_package_suffix(name)}"
     (sources / "DpsrApp.swift").write_text(
         "import SwiftUI\n\n"
         "@main\n"
@@ -395,6 +399,13 @@ def _write_ios_project(destination: Path, name: str) -> None:
         "}\n",
         encoding="utf-8",
     )
+
+
+def _write_ios_project_spec(destination: Path, name: str) -> None:
+    app = destination / "app"
+    app.mkdir(parents=True, exist_ok=True)
+    app_name = _pascal_name(name)
+    bundle = f"com.digitalparagon.{_package_suffix(name)}"
     (app / "project.yml").write_text(
         f"name: {app_name}\n"
         "options:\n"
@@ -409,9 +420,16 @@ def _write_ios_project(destination: Path, name: str) -> None:
         "      base:\n"
         f"        PRODUCT_BUNDLE_IDENTIFIER: {bundle}\n"
         "        SWIFT_VERSION: 6.0\n"
-        "        CODE_SIGN_STYLE: Automatic\n",
+        "        CODE_SIGN_STYLE: Automatic\n"
+        "        GENERATE_INFOPLIST_FILE: YES\n"
+        f"        INFOPLIST_KEY_CFBundleDisplayName: {app_name}\n"
+        "        INFOPLIST_KEY_UILaunchScreen_Generation: YES\n",
         encoding="utf-8",
     )
+
+
+def _write_ios_workflow(destination: Path, name: str) -> None:
+    app_name = _pascal_name(name)
     workflow = destination / ".github" / "workflows" / "ios.yml"
     workflow.parent.mkdir(parents=True, exist_ok=True)
     workflow.write_text(
@@ -432,6 +450,12 @@ def _write_ios_project(destination: Path, name: str) -> None:
         "          -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO\n",
         encoding="utf-8",
     )
+
+
+def _write_ios_project(destination: Path, name: str) -> None:
+    _write_ios_source(destination)
+    _write_ios_project_spec(destination, name)
+    _write_ios_workflow(destination, name)
     (destination / ".gitignore").write_text("app/*.xcodeproj/\nDerivedData/\n", encoding="utf-8")
 
 
@@ -505,6 +529,24 @@ def _write_react_native_workflow(destination: Path) -> None:
         "        working-directory: app/android\n",
         encoding="utf-8",
     )
+
+
+def refresh_mobile_build_files(project: Project) -> Project:
+    if project.profile not in MOBILE_PROFILES:
+        raise ValueError(f"Project '{project.name}' is not a mobile profile.")
+    if not _managed_destination(project.path):
+        raise ValueError("Mobile template refresh is limited to managed DPSR projects.")
+    if project.profile == "android":
+        _write_android_build_config(project.path, project.name)
+        _write_android_workflow(project.path)
+    elif project.profile == "ios":
+        _write_ios_project_spec(project.path, project.name)
+        _write_ios_workflow(project.path, project.name)
+    elif project.profile == "flutter":
+        _write_flutter_workflow(project.path)
+    else:
+        _write_react_native_workflow(project.path)
+    return register_project(project.path)
 
 
 def init_mobile_project(name: str, profile_name: str, target: Path | None = None):

--- a/tests/test_external_runner.py
+++ b/tests/test_external_runner.py
@@ -113,7 +113,7 @@ timeout = 3600
             push_mock.assert_called_once()
             self.assertEqual(gh_mock.call_args.args[:3], ("repo", "create", "octocat/demo-ios"))
 
-    def test_dispatch_records_remote_run_identity(self) -> None:
+    def test_dispatch_records_remote_run_identity_through_rest_api(self) -> None:
         project = Project(
             name="demo",
             path=Path("/tmp/demo"),
@@ -129,28 +129,33 @@ timeout = 3600
                 }
             },
         )
-        run_list = json.dumps([
-            {
-                "databaseId": 12345,
-                "createdAt": "2026-08-24T08:00:00Z",
-                "status": "queued",
-                "conclusion": "",
-                "url": "https://github.com/octocat/demo/actions/runs/12345",
-            }
-        ])
+        workflow_runs = json.dumps({
+            "workflow_runs": [
+                {
+                    "id": 12345,
+                    "created_at": "2026-08-24T08:00:00Z",
+                    "status": "queued",
+                    "conclusion": None,
+                    "html_url": "https://github.com/octocat/demo/actions/runs/12345",
+                }
+            ]
+        })
         responses = [
             {"returncode": 0, "stdout": "", "stderr": ""},
-            {"returncode": 0, "stdout": run_list, "stderr": ""},
+            {"returncode": 0, "stdout": workflow_runs, "stderr": ""},
         ]
         with (
             mock.patch.object(github_actions, "require_auth", return_value={"safe": True}),
-            mock.patch.object(github_actions, "_gh", side_effect=responses),
+            mock.patch.object(github_actions, "_utc", return_value="2026-08-24T08:00:00Z"),
+            mock.patch.object(github_actions, "_gh", side_effect=responses) as gh_mock,
         ):
             external = github_actions.dispatch(project, "build")
         self.assertEqual(external["provider"], "github-actions")
         self.assertEqual(external["run_id"], 12345)
         self.assertEqual(external["workflow"], "android.yml")
         self.assertEqual(external["status"], "queued")
+        self.assertEqual(gh_mock.call_args_list[1].args[0], "api")
+        self.assertIn("event=workflow_dispatch", gh_mock.call_args_list[1].args[1])
 
     def test_external_job_dispatch_and_refresh_roundtrip(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/tests/test_mobile_platform.py
+++ b/tests/test_mobile_platform.py
@@ -94,7 +94,7 @@ class MobilePlatformTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "Node.js 22.13 or newer"):
                 mobile._ensure_react_native_node()
 
-    def test_android_template_targets_current_toolchain_and_external_runner(self) -> None:
+    def test_android_template_targets_available_sdk_and_external_runner(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             base = Path(temp)
             project_root = base / "android-app"
@@ -109,11 +109,14 @@ class MobilePlatformTests(unittest.TestCase):
             workflow = (project_root / ".github" / "workflows" / "android.yml").read_text(encoding="utf-8")
             self.assertIn('id("com.android.application") version "9.3.0"', root_gradle)
             self.assertNotIn("org.jetbrains.kotlin.android", root_gradle)
-            self.assertIn("compileSdk = 37", module_gradle)
+            self.assertIn("compileSdk = 36", module_gradle)
+            self.assertIn("targetSdk = 36", module_gradle)
+            self.assertIn("platforms;android-36", workflow)
+            self.assertIn("build-tools;36.0.0", workflow)
             self.assertIn("gradle-version: '9.5.0'", workflow)
             self.assertIn("ubuntu-latest", workflow)
 
-    def test_ios_template_uses_macos_runner_and_xcodegen(self) -> None:
+    def test_ios_template_generates_info_plist_on_macos_runner(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             base = Path(temp)
             project_root = base / "ios-app"
@@ -124,11 +127,35 @@ class MobilePlatformTests(unittest.TestCase):
 
             self.assertEqual(project.runner, "github-actions")
             self.assertTrue((project_root / "app" / "Sources" / "DpsrApp.swift").is_file())
-            self.assertTrue((project_root / "app" / "project.yml").is_file())
+            spec = (project_root / "app" / "project.yml").read_text(encoding="utf-8")
             workflow = (project_root / ".github" / "workflows" / "ios.yml").read_text(encoding="utf-8")
+            self.assertIn("GENERATE_INFOPLIST_FILE: YES", spec)
+            self.assertIn("INFOPLIST_KEY_CFBundleDisplayName", spec)
             self.assertIn("runs-on: macos-15", workflow)
             self.assertIn("xcodegen generate --spec app/project.yml", workflow)
             self.assertIn("CODE_SIGNING_ALLOWED=NO", workflow)
+
+    def test_mobile_refresh_updates_build_files_without_overwriting_source(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            base = Path(temp)
+            managed = base / "managed"
+            project_root = managed / "android-app"
+            state = base / "state"
+            with (
+                mock.patch.object(mobile, "PROJECTS_ROOT", managed),
+                mock.patch.object(registry, "STATE_ROOT", state),
+                mock.patch.object(registry, "REGISTRY_PATH", state / "projects.json"),
+            ):
+                project = mobile.init_mobile_project("android-app", "android", project_root)
+                source = next((project_root / "app" / "app" / "src" / "main" / "java").rglob("MainActivity.kt"))
+                source.write_text("custom application source\n", encoding="utf-8")
+                module = project_root / "app" / "app" / "build.gradle.kts"
+                module.write_text("compileSdk = 37\n", encoding="utf-8")
+                refreshed = mobile.refresh_mobile_build_files(project)
+
+            self.assertEqual(refreshed.name, "android-app")
+            self.assertEqual(source.read_text(encoding="utf-8"), "custom application source\n")
+            self.assertIn("compileSdk = 36", module.read_text(encoding="utf-8"))
 
     def test_api_routes_mobile_profiles_to_mobile_engine(self) -> None:
         project = Project(
@@ -144,6 +171,24 @@ class MobilePlatformTests(unittest.TestCase):
             row = api.create_project("demo", "flutter")
         init_mock.assert_called_once_with("demo", "flutter")
         self.assertEqual(row["profile"], "flutter")
+
+    def test_api_refresh_routes_existing_mobile_project(self) -> None:
+        project = Project(
+            name="demo",
+            path=Path("/tmp/demo"),
+            profile="ios",
+            runner="github-actions",
+            commands={},
+            services={},
+            metadata={},
+        )
+        with (
+            mock.patch.object(api, "get_project", return_value=project),
+            mock.patch.object(api, "refresh_mobile_build_files", return_value=project) as refresh_mock,
+        ):
+            row = api.refresh_project_template("demo")
+        refresh_mock.assert_called_once_with(project)
+        self.assertEqual(row["profile"], "ios")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the two failures found by the first real native mobile GitHub Actions builds.

Android:
- target/compile SDK 36, which is available on the hosted Android SDK repository
- keep build-tools 36.0.0, AGP 9.3, Gradle 9.5

Native iOS:
- enable generated Info.plist in the XcodeGen target so simulator app validation succeeds

Managed project maintenance:
- add `dpsr project refresh-template <name>` for mobile projects
- refresh rewrites only DPSR-managed build/CI files and preserves application source
- existing bound repositories can then be republished through the normal safe publish path

External runner:
- initial workflow dispatch now discovers Actions runs through the REST API instead of the incompatible `gh run list --event` flag
- repeated publishes use an update commit message once a project already has a Git repository

Regression coverage includes the exact Android SDK, iOS plist, source-preservation, API refresh routing, and REST dispatch identity paths.