### PR TITLE
Platform v2: final metadata and MCP polish

### DIFF
--- a/platform/profiles/android.json
+++ b/platform/profiles/android.json
@@ -3,7 +3,7 @@
     "name": "android",
     "title": "Native Android",
     "category": "mobile",
-    "description": "Native Kotlin Android application profile targeting API 37 with AGP 9.3, Gradle 9.5, CI lint/tests/debug builds, and release-ready project structure.",
+    "description": "Native Kotlin Android application profile targeting API 36 with AGP 9.3, Gradle 9.5, CI lint/tests/debug builds, and release-ready project structure.",
     "runner": "github-actions",
     "stack": ["kotlin", "android", "gradle"],
     "capabilities": ["android", "testing", "ci", "release"],

--- a/security_lab/mcp_server.py
+++ b/security_lab/mcp_server.py
@@ -107,6 +107,12 @@ def platform_project_init(name: str, profile_name: str) -> dict[str, Any]:
 
 
 @mcp.tool()
+def platform_project_refresh_template(name: str) -> dict[str, Any]:
+    """Refresh DPSR-managed mobile build and CI files without overwriting application source."""
+    return platform_api.refresh_project_template(name)
+
+
+@mcp.tool()
 def platform_project_delete(name: str) -> dict[str, Any]:
     """Delete one registered project only when it resides inside the managed DPSR project workspace."""
     return platform_api.delete_project(name)


### PR DESCRIPTION
Final consistency cleanup after the validated Android/iOS and dashboard rollout.

- align the Native Android profile description with the proven API 36 build target
- expose the existing source-preserving mobile template refresh API as a first-class MCP tool

No execution boundary is widened; the refresh operation already validates managed mobile projects and rewrites only DPSR-owned build/CI files.