### PR TITLE
Recovery: renew wake credential outside Codespace

### DIFF
--- a/.github/workflows/refresh-wake-credential.yml
+++ b/.github/workflows/refresh-wake-credential.yml
@@ -1,0 +1,121 @@
+name: DPSR Wake Credential Recovery
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: dpsr-wake-credential-recovery
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    if: >-
+      github.event.issue.title == '[DPSR-WAKE-AUTH] refresh credential' &&
+      github.event.issue.user.login == github.repository_owner
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Authorize isolated Codespaces credential
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          ACTIONS_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          auth_log="$RUNNER_TEMP/wake-auth.log"
+          auth_config="$RUNNER_TEMP/wake-gh"
+          mkdir -p "$auth_config"
+          : > "$auth_log"
+
+          (
+            env -u GH_TOKEN -u GITHUB_TOKEN \
+              GH_CONFIG_DIR="$auth_config" \
+              GH_PROMPT_DISABLED=1 \
+              BROWSER=true \
+              gh auth login \
+                --hostname github.com \
+                --git-protocol https \
+                --web \
+                --scopes 'codespace,repo' \
+                >"$auth_log" 2>&1
+          ) &
+          auth_pid=$!
+
+          code=""
+          for _attempt in $(seq 1 30); do
+            code="$(grep -Eo '[A-Z0-9]{4}-[A-Z0-9]{4}' "$auth_log" | head -n 1 || true)"
+            if [ -n "$code" ]; then
+              break
+            fi
+            if ! kill -0 "$auth_pid" 2>/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+
+          if [ -z "$code" ]; then
+            kill "$auth_pid" 2>/dev/null || true
+            wait "$auth_pid" 2>/dev/null || true
+            GH_TOKEN="$ACTIONS_TOKEN" gh api \
+              "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments" \
+              -f body='Wake credential recovery could not start GitHub device authorization.'
+            exit 1
+          fi
+
+          message="$(printf 'Wake credential authorization is ready.\n\nOpen https://github.com/login/device and enter **%s**.\n\nThis credential is isolated to the external Codespaces recovery controller.' "$code")"
+          GH_TOKEN="$ACTIONS_TOKEN" gh api \
+            "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments" \
+            -f body="$message" >/dev/null
+
+          if ! wait "$auth_pid"; then
+            GH_TOKEN="$ACTIONS_TOKEN" gh api \
+              "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments" \
+              -f body='Wake credential authorization did not complete successfully.' >/dev/null
+            exit 1
+          fi
+
+          token="$(env -u GH_TOKEN -u GITHUB_TOKEN GH_CONFIG_DIR="$auth_config" gh auth token --hostname github.com)"
+          if [ -z "$token" ]; then
+            GH_TOKEN="$ACTIONS_TOKEN" gh api \
+              "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments" \
+              -f body='Wake credential authorization completed without a usable token.' >/dev/null
+            exit 1
+          fi
+          echo "::add-mask::$token"
+
+          login="$(GH_TOKEN="$token" gh api user --jq .login)"
+          if [ "${login,,}" != "${REPOSITORY_OWNER,,}" ]; then
+            GH_TOKEN="$ACTIONS_TOKEN" gh api \
+              "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments" \
+              -f body='Wake credential authorization was completed by the wrong GitHub account; no secret was changed.' >/dev/null
+            exit 1
+          fi
+
+          GH_TOKEN="$token" gh api '/user/codespaces?per_page=1' >/dev/null
+          GH_TOKEN="$token" gh secret set DPSR_CODESPACES_TOKEN \
+            --repo "$REPOSITORY" \
+            --body "$token"
+
+          GH_TOKEN="$ACTIONS_TOKEN" gh api \
+            "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments" \
+            -f body='DPSR external wake credential refreshed and validated for Codespaces access.' >/dev/null
+          GH_TOKEN="$ACTIONS_TOKEN" gh api \
+            --method PATCH \
+            "repos/$REPOSITORY/issues/$ISSUE_NUMBER" \
+            -f state=closed >/dev/null
+
+      - name: Report recovery failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh api "repos/$REPOSITORY/issues/$ISSUE_NUMBER/comments" \
+            -f body='DPSR wake credential recovery failed. The existing Actions secret was left unchanged.' >/dev/null || true


### PR DESCRIPTION
Adds an owner-only GitHub Actions recovery path for the `DPSR_CODESPACES_TOKEN` secret.

This closes the final recovery dependency: if the Codespace is asleep or its bridge is unavailable, an owner-authored issue can start a GitHub device authorization flow entirely on a hosted runner, validate the authorized account and Codespaces access, and replace the encrypted wake secret without exposing the token.

Trigger: `[DPSR-WAKE-AUTH] refresh credential`.

The workflow never prints the OAuth token and leaves the existing secret unchanged on failure.