### PR TITLE
Align production probe with Digital Paragon identity

### DIFF
--- a/security_lab/mcp_probe.py
+++ b/security_lab/mcp_probe.py
@@ -44,7 +44,7 @@ async def probe() -> int:
                 "platform": (
                     not platform.is_error
                     and isinstance(platform_content, dict)
-                    and platform_content.get("platform") == "dpsr-v2"
+                    and platform_content.get("platform") == "Digital Paragon"
                 ),
                 "repo_status": not repo_status.is_error,
                 "project_command": not command.is_error,


### PR DESCRIPTION
Updates the live MCP production probe to expect the permanent Digital Paragon platform identity instead of the removed versioned legacy identifier. No runtime behavior or execution boundary changes.