### PR TITLE
Replace oversized button treatments with restrained controls

### DIFF
--- a/dashboard/web/design-system.css
+++ b/dashboard/web/design-system.css
@@ -296,6 +296,129 @@ pre,
   border-radius:inherit;
 }
 
+/* Button language: remove oversized pills and tile-like active states. */
+.status-pill,
+.chip{
+  min-height:auto;
+  padding:0;
+  border:0;
+  border-radius:0;
+  background:transparent;
+  gap:7px;
+  font-size:10px;
+  line-height:1.2;
+  letter-spacing:.09em;
+  text-transform:uppercase;
+}
+
+.status-pill::before{
+  width:6px;
+  height:6px;
+  box-shadow:none;
+}
+
+#platform-status{
+  align-self:center;
+}
+
+.segmented{
+  gap:0;
+  padding:0;
+  border:0;
+  border-bottom:1px solid #1a2530;
+  border-radius:0;
+  background:transparent;
+}
+
+.segment{
+  position:relative;
+  min-height:40px;
+  padding:10px 12px 11px;
+  border-radius:0;
+  background:transparent;
+}
+
+.segment.active{
+  background:transparent;
+  color:var(--blue-2);
+}
+
+.segment.active::after{
+  content:"";
+  position:absolute;
+  left:18%;
+  right:18%;
+  bottom:-1px;
+  height:2px;
+  background:currentColor;
+}
+
+.bottom-nav{
+  padding:5px 4px 4px;
+  border-radius:14px;
+  background:rgba(7,11,16,.96);
+  border-color:#1d2935;
+  box-shadow:0 10px 28px rgba(0,0,0,.28);
+}
+
+.nav-button{
+  position:relative;
+  min-height:62px;
+  padding:9px 6px 8px;
+  border-radius:0;
+  background:transparent!important;
+  color:#7f8b99;
+}
+
+.nav-button.active{
+  background:transparent!important;
+  color:var(--blue-2);
+}
+
+.nav-button.active::before{
+  content:"";
+  position:absolute;
+  top:-5px;
+  left:50%;
+  width:28px;
+  height:2px;
+  transform:translateX(-50%);
+  background:currentColor;
+}
+
+.nav-icon{
+  width:28px;
+  height:25px;
+  margin:0 auto 4px;
+  background:transparent!important;
+}
+
+.nav-label{
+  font-size:10px;
+  letter-spacing:.06em;
+}
+
+.quick-action,
+.control{
+  border-radius:10px;
+  background:#090e13;
+  border-color:#18232d;
+}
+
+.quick-action .qa-icon,
+.control-icon{
+  width:28px;
+  height:28px;
+  border-radius:0;
+  background:transparent;
+}
+
+.primary,
+.secondary,
+.icon-button{
+  border-radius:8px;
+}
+
 @media (max-width:760px){
   .content{padding-left:20px;padding-right:20px}
   .topbar{padding-top:16px;padding-bottom:24px}


### PR DESCRIPTION
Refine APOTHEON ONE interaction styling without changing application logic.

Changes:
- Remove pill containers from online/offline/status labels
- Replace filled segmented tabs with a thin active underline
- Remove the large filled bottom-nav selection block and use a compact top indicator
- Tighten quick actions, controls, and icon-button corner treatment
- Preserve layout, navigation behavior, data bindings, product icons, controller, and backend

CSS-only change for straightforward rollback.