### PR TITLE
Add 45-second deployment feedback watcher

### DIFF
--- a/.github/workflows/deployment-feedback.yml
+++ b/.github/workflows/deployment-feedback.yml
@@ -20,17 +20,42 @@ jobs:
       (github.event.issue.title == '[DPSR-WAKE] start Codespace' ||
        github.event.issue.title == '[DPSR-WAKE] restart Codespace' ||
        github.event.issue.title == '[DPSR-WAKE] refresh Codespace' ||
-       github.event.issue.title == '[DPSR-WAKE] stop Codespace')
+       github.event.issue.title == '[DPSR-WAKE] stop Codespace' ||
+       github.event.issue.title == '[DPSR-FEEDBACK] watch deployment')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}
       REPOSITORY: ${{ github.repository }}
-      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      REQUEST_ISSUE: ${{ github.event.issue.number }}
+      REQUEST_TITLE: ${{ github.event.issue.title }}
+      REQUEST_BODY: ${{ github.event.issue.body }}
       INTERVAL_SECONDS: '45'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Resolve deployment issue
+        id: target
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          if [[ "$REQUEST_TITLE" == '[DPSR-FEEDBACK] watch deployment' ]]; then
+            target="$(printf '%s\n' "${REQUEST_BODY:-}" | sed -nE 's/^issue:[[:space:]]*([0-9]+)[[:space:]]*$/\1/p' | head -n 1)"
+            if [[ -z "$target" ]]; then
+              printf '%s\n' 'Feedback request requires `issue: NUMBER`.' >&2
+              exit 2
+            fi
+          else
+            target="$REQUEST_ISSUE"
+          fi
+          printf 'issue_number=%s\n' "$target" >> "$GITHUB_OUTPUT"
+
       - name: Stream deployment feedback
         shell: bash
-        run: bash scripts/apotheon-feedback-watch.sh "$ISSUE_NUMBER"
+        run: bash scripts/apotheon-feedback-watch.sh "${{ steps.target.outputs.issue_number }}"
+
+      - name: Close feedback request
+        if: always() && github.event.issue.title == '[DPSR-FEEDBACK] watch deployment'
+        shell: bash
+        run: gh issue close "$REQUEST_ISSUE" --repo "$REPOSITORY" --reason completed || true

--- a/.github/workflows/deployment-feedback.yml
+++ b/.github/workflows/deployment-feedback.yml
@@ -1,0 +1,36 @@
+name: APOTHEON ONE Deployment Feedback
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: apotheon-one-feedback-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  feedback:
+    if: >-
+      github.event.issue.user.login == github.repository_owner &&
+      (github.event.issue.title == '[DPSR-WAKE] start Codespace' ||
+       github.event.issue.title == '[DPSR-WAKE] restart Codespace' ||
+       github.event.issue.title == '[DPSR-WAKE] refresh Codespace' ||
+       github.event.issue.title == '[DPSR-WAKE] stop Codespace')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPOSITORY: ${{ github.repository }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      INTERVAL_SECONDS: '45'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Stream deployment feedback
+        shell: bash
+        run: bash scripts/apotheon-feedback-watch.sh "$ISSUE_NUMBER"

--- a/.github/workflows/deployment-feedback.yml
+++ b/.github/workflows/deployment-feedback.yml
@@ -33,7 +33,7 @@ jobs:
       INTERVAL_SECONDS: '45'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
 
       - name: Resolve deployment issue
         id: target

--- a/scripts/apotheon-feedback-watch.sh
+++ b/scripts/apotheon-feedback-watch.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPOSITORY="${REPOSITORY:-thewire1o1/Security-Lab}"
+ISSUE_NUMBER="${1:-${ISSUE_NUMBER:-}}"
+INTERVAL_SECONDS="${INTERVAL_SECONDS:-45}"
+MARKER='<!-- apotheon-deployment-feedback -->'
+
+if [[ -z "${ISSUE_NUMBER}" ]]; then
+  printf 'usage: %s ISSUE_NUMBER\n' "$0" >&2
+  exit 2
+fi
+
+for command in gh jq; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    printf 'missing required command: %s\n' "$command" >&2
+    exit 3
+  fi
+done
+
+gh auth status >/dev/null 2>&1 || {
+  printf '%s\n' 'GitHub CLI is not authenticated.' >&2
+  exit 4
+}
+
+issue_json="$(gh api "repos/${REPOSITORY}/issues/${ISSUE_NUMBER}")"
+issue_title="$(jq -r '.title' <<<"$issue_json")"
+issue_created="$(jq -r '.created_at' <<<"$issue_json")"
+
+find_feedback_comment() {
+  gh api "repos/${REPOSITORY}/issues/${ISSUE_NUMBER}/comments?per_page=100" \
+    | jq -r --arg marker "$MARKER" '[.[] | select(.body | contains($marker))] | last | .id // empty'
+}
+
+publish_feedback() {
+  local body="$1"
+  local comment_id
+  comment_id="$(find_feedback_comment)"
+
+  if [[ -n "$comment_id" ]]; then
+    gh api --method PATCH "repos/${REPOSITORY}/issues/comments/${comment_id}" \
+      -f body="$body" >/dev/null
+  else
+    gh api --method POST "repos/${REPOSITORY}/issues/${ISSUE_NUMBER}/comments" \
+      -f body="$body" >/dev/null
+  fi
+}
+
+extract_links() {
+  local comments="$1"
+  local console codespace mcp
+
+  console="$(jq -r '[.[].body | scan("https://[A-Za-z0-9-]+-8765\\.app\\.github\\.dev")] | last // empty' <<<"$comments")"
+  codespace="$(jq -r '[.[].body | scan("https://[A-Za-z0-9-]+\\.github\\.dev")] | last // empty' <<<"$comments")"
+  mcp="$(jq -r '[.[].body | scan("https://[A-Za-z0-9-]+-8766\\.app\\.github\\.dev/mcp")] | last // empty' <<<"$comments")"
+
+  printf '%s\n%s\n%s\n' "$console" "$codespace" "$mcp"
+}
+
+while :; do
+  now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  runs_json="$(gh api "repos/${REPOSITORY}/actions/workflows/wake-codespace.yml/runs?event=issues&per_page=50")"
+  run_json="$(jq -c \
+    --arg title "$issue_title" \
+    --arg created "$issue_created" \
+    '[.workflow_runs[] | select(.display_title == $title and .created_at >= $created)] | sort_by(.created_at) | last // empty' \
+    <<<"$runs_json")"
+
+  run_status='waiting'
+  run_conclusion=''
+  run_id=''
+  head_sha=''
+  active_step='Waiting for Wake Controller run'
+
+  if [[ -n "$run_json" ]]; then
+    run_id="$(jq -r '.id' <<<"$run_json")"
+    run_status="$(jq -r '.status // "unknown"' <<<"$run_json")"
+    run_conclusion="$(jq -r '.conclusion // empty' <<<"$run_json")"
+    head_sha="$(jq -r '.head_sha // empty' <<<"$run_json")"
+
+    jobs_json="$(gh api "repos/${REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100")"
+    active_step="$(jq -r '[.jobs[].steps[]? | select(.status == "in_progress") | .name] | first // empty' <<<"$jobs_json")"
+
+    if [[ -z "$active_step" ]]; then
+      if [[ "$run_status" == 'completed' && "$run_conclusion" == 'success' ]]; then
+        active_step='Wake Controller completed successfully'
+      elif [[ "$run_status" == 'completed' ]]; then
+        active_step="Wake Controller completed: ${run_conclusion:-unknown}"
+      else
+        active_step="Workflow status: ${run_status}"
+      fi
+    fi
+  fi
+
+  comments_json="$(gh api "repos/${REPOSITORY}/issues/${ISSUE_NUMBER}/comments?per_page=100")"
+  mapfile -t links < <(extract_links "$comments_json")
+  console_url="${links[0]:-}"
+  codespace_url="${links[1]:-}"
+  mcp_url="${links[2]:-}"
+
+  body=$(cat <<EOF
+${MARKER}
+### APOTHEON deployment feedback
+
+Updated: \`${now}\`  
+Workflow: \`${run_status}${run_conclusion:+ / ${run_conclusion}}\`  
+Step: \`${active_step}\`  
+Head: \`${head_sha:-pending}\`
+
+APOTHEON ONE console: ${console_url:-pending}  
+Codespace: ${codespace_url:-pending}  
+MCP: ${mcp_url:-pending}
+
+Watcher interval: \`${INTERVAL_SECONDS}s\`
+EOF
+)
+
+  publish_feedback "$body"
+  printf '[%s] %s | %s\n' "$now" "$run_status" "$active_step"
+
+  if [[ "$run_status" == 'completed' ]]; then
+    if [[ "$run_conclusion" != 'success' ]]; then
+      exit 1
+    fi
+    if [[ -n "$console_url" && -n "$codespace_url" && -n "$mcp_url" ]]; then
+      exit 0
+    fi
+  fi
+
+  sleep "$INTERVAL_SECONDS"
+done

--- a/scripts/apotheon-feedback-watch.sh
+++ b/scripts/apotheon-feedback-watch.sh
@@ -66,28 +66,31 @@ while :; do
     '[.workflow_runs[] | select(.display_title == $title and .created_at >= $created)] | sort_by(.created_at) | last // empty' \
     <<<"$runs_json")"
 
-  run_status='waiting'
-  run_conclusion=''
   run_id=''
   head_sha=''
-  active_step='Waiting for Wake Controller run'
+  wake_status='waiting'
+  wake_conclusion=''
+  active_step='Waiting for Wake Controller job'
 
   if [[ -n "$run_json" ]]; then
     run_id="$(jq -r '.id' <<<"$run_json")"
-    run_status="$(jq -r '.status // "unknown"' <<<"$run_json")"
-    run_conclusion="$(jq -r '.conclusion // empty' <<<"$run_json")"
     head_sha="$(jq -r '.head_sha // empty' <<<"$run_json")"
-
     jobs_json="$(gh api "repos/${REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100")"
-    active_step="$(jq -r '[.jobs[].steps[]? | select(.status == "in_progress") | .name] | first // empty' <<<"$jobs_json")"
+    wake_json="$(jq -c '[.jobs[] | select(.name == "wake")] | first // empty' <<<"$jobs_json")"
 
-    if [[ -z "$active_step" ]]; then
-      if [[ "$run_status" == 'completed' && "$run_conclusion" == 'success' ]]; then
-        active_step='Wake Controller completed successfully'
-      elif [[ "$run_status" == 'completed' ]]; then
-        active_step="Wake Controller completed: ${run_conclusion:-unknown}"
-      else
-        active_step="Workflow status: ${run_status}"
+    if [[ -n "$wake_json" ]]; then
+      wake_status="$(jq -r '.status // "unknown"' <<<"$wake_json")"
+      wake_conclusion="$(jq -r '.conclusion // empty' <<<"$wake_json")"
+      active_step="$(jq -r '[.steps[]? | select(.status == "in_progress") | .name] | first // empty' <<<"$wake_json")"
+
+      if [[ -z "$active_step" ]]; then
+        if [[ "$wake_status" == 'completed' && "$wake_conclusion" == 'success' ]]; then
+          active_step='Wake Controller completed successfully'
+        elif [[ "$wake_status" == 'completed' ]]; then
+          active_step="Wake Controller completed: ${wake_conclusion:-unknown}"
+        else
+          active_step="Wake job status: ${wake_status}"
+        fi
       fi
     fi
   fi
@@ -103,7 +106,7 @@ ${MARKER}
 ### APOTHEON deployment feedback
 
 Updated: \`${now}\`  
-Workflow: \`${run_status}${run_conclusion:+ / ${run_conclusion}}\`  
+Wake job: \`${wake_status}${wake_conclusion:+ / ${wake_conclusion}}\`  
 Step: \`${active_step}\`  
 Head: \`${head_sha:-pending}\`
 
@@ -116,10 +119,10 @@ EOF
 )
 
   publish_feedback "$body"
-  printf '[%s] %s | %s\n' "$now" "$run_status" "$active_step"
+  printf '[%s] %s | %s\n' "$now" "$wake_status" "$active_step"
 
-  if [[ "$run_status" == 'completed' ]]; then
-    if [[ "$run_conclusion" != 'success' ]]; then
+  if [[ "$wake_status" == 'completed' ]]; then
+    if [[ "$wake_conclusion" != 'success' ]]; then
       exit 1
     fi
     if [[ -n "$console_url" && -n "$codespace_url" && -n "$mcp_url" ]]; then


### PR DESCRIPTION
Add a self-running APOTHEON ONE deployment feedback channel without changing dashboard, controller, backend, or Codespace lifecycle logic.

Changes:
- Add `scripts/apotheon-feedback-watch.sh`
- Poll the Wake Controller every 45 seconds
- Update one GitHub issue comment in place instead of spamming comments
- Report the active wake step, wake job state, and head SHA
- Surface the console, Codespace, and MCP links as soon as the Wake Controller posts them
- Add a separate issue-triggered feedback workflow with read-only Actions access and issue-comment write access

This gives connected GitHub a continuously refreshed status source. It does not bypass ChatGPT's own one-hour scheduled-notification limit or inject messages directly into a chat.