### PR TITLE
Add target-aware orchestration and interactive Active Run

### DIFF
--- a/bin/labscan
+++ b/bin/labscan
@@ -1,20 +1,90 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+
+TARGET="${1:-lab}"
+PROFILE="${2:-standard}"
 STAMP="$(date +%Y%m%d-%H%M%S)"
-OUT="reports/lab-${STAMP}"
+OUT="reports/lab-${STAMP}-${TARGET}"
 mkdir -p "$OUT"
 
-echo "[+] Checking local training targets..."
+stage() {
+  printf 'APOTHEON_STAGE|%s|%s|%s|%s\n' "$1" "$2" "$3" "$4"
+}
+
+case "$PROFILE" in
+  quick|standard|deep) ;;
+  *)
+    printf 'Unsupported scan profile: %s\n' "$PROFILE" >&2
+    exit 2
+    ;;
+esac
+
+declare -a URLS=()
+PORTS=""
+TARGET_LABEL=""
+case "$TARGET" in
+  lab)
+    TARGET_LABEL="Entire Training Lab"
+    PORTS="3000,8080,8081"
+    URLS=("http://127.0.0.1:3000" "http://127.0.0.1:8080" "http://127.0.0.1:8081")
+    ;;
+  juice-shop)
+    TARGET_LABEL="OWASP Juice Shop"
+    PORTS="3000"
+    URLS=("http://127.0.0.1:3000")
+    ;;
+  dvwa)
+    TARGET_LABEL="Vulnerable Web App"
+    PORTS="8080"
+    URLS=("http://127.0.0.1:8080")
+    ;;
+  webgoat)
+    TARGET_LABEL="OWASP WebGoat"
+    PORTS="8081"
+    URLS=("http://127.0.0.1:8081")
+    ;;
+  *)
+    printf 'Unsupported scan target: %s\n' "$TARGET" >&2
+    exit 2
+    ;;
+esac
+
+stage scope running "Confirm target" "Locking this run to ${TARGET_LABEL}."
+printf '[+] Target: %s\n' "$TARGET_LABEL"
+printf '[+] Profile: %s\n' "$PROFILE"
 docker compose -f lab/docker-compose.yml ps || true
+stage scope completed "Confirm target" "Target confirmed inside the local APOTHEON training lab."
 
-nmap -Pn -sV -p 3000,8080,8081 127.0.0.1 -oA "$OUT/nmap-local" || true
+stage discover running "Discover services" "Network Discovery is identifying reachable services with Nmap."
+declare -a NMAP_ARGS=(-Pn -sV)
+if [[ "$PROFILE" == "deep" ]]; then
+  NMAP_ARGS+=(-sC)
+fi
+nmap "${NMAP_ARGS[@]}" -p "$PORTS" 127.0.0.1 -oA "$OUT/nmap-local" || true
+stage discover completed "Discover services" "Service discovery finished. Detailed Nmap output was saved with this run."
 
-for url in http://127.0.0.1:3000 http://127.0.0.1:8080 http://127.0.0.1:8081; do
+stage inspect running "Inspect application" "Reading the selected web application response and collecting HTTP details."
+for url in "${URLS[@]}"; do
   name="$(printf '%s' "$url" | tr -cs '[:alnum:]' '_')"
   curl -skI --max-time 10 "$url" > "$OUT/${name}-headers.txt" 2>&1 || true
-  if command -v nuclei >/dev/null 2>&1; then
-    nuclei -silent -u "$url" -severity info,low,medium,high,critical >> "$OUT/nuclei.txt" 2>/dev/null || true
-  fi
 done
+stage inspect completed "Inspect application" "HTTP inspection finished for the selected target."
 
-echo "[+] Results: $OUT"
+if [[ "$PROFILE" == "quick" ]]; then
+  stage weakness skipped "Check security weaknesses" "Quick Check stops after service and HTTP inspection. Choose Standard or Deep to run vulnerability templates."
+else
+  if command -v nuclei >/dev/null 2>&1; then
+    stage weakness running "Check security weaknesses" "Web Vulnerability Checks are comparing the target against Nuclei templates."
+    for url in "${URLS[@]}"; do
+      nuclei -silent -u "$url" -severity info,low,medium,high,critical >> "$OUT/nuclei.txt" 2>/dev/null || true
+    done
+    stage weakness completed "Check security weaknesses" "Known-pattern vulnerability checks finished and were saved with this run."
+  else
+    stage weakness skipped "Check security weaknesses" "Nuclei is not installed in this runtime, so vulnerability template checks were skipped."
+  fi
+fi
+
+stage summarize running "Organize results" "Saving the run evidence so APOTHEON can present it as a result instead of raw terminal output."
+printf 'target=%s\nprofile=%s\ncompleted=%s\n' "$TARGET" "$PROFILE" "$(date -Iseconds)" > "$OUT/run.txt"
+stage summarize completed "Organize results" "Run evidence is saved and ready for review."
+printf '[+] Results: %s\n' "$OUT"

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -8,7 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from security_lab.dashboard import main  # noqa: E402
+from security_lab.orchestrator import main  # noqa: E402
 
 
 if __name__ == "__main__":

--- a/dashboard/web/app.js
+++ b/dashboard/web/app.js
@@ -13,6 +13,11 @@
   uxStyles.href = "/ux-polish.css";
   document.head.appendChild(uxStyles);
 
+  const orchestratorStyles = document.createElement("link");
+  orchestratorStyles.rel = "stylesheet";
+  orchestratorStyles.href = "/orchestrator.css";
+  document.head.appendChild(orchestratorStyles);
+
   const core = document.createElement("script");
   core.src = "/app-base.js";
   core.async = false;
@@ -26,6 +31,11 @@
     uxBehavior.src = "/ux-behavior.js";
     uxBehavior.async = false;
     document.head.appendChild(uxBehavior);
+
+    const orchestrator = document.createElement("script");
+    orchestrator.src = "/orchestrator.js";
+    orchestrator.async = false;
+    document.head.appendChild(orchestrator);
   });
   document.head.appendChild(core);
 })();

--- a/dashboard/web/orchestrator.css
+++ b/dashboard/web/orchestrator.css
@@ -1,0 +1,204 @@
+/* APOTHEON ONE orchestration layer: target -> operation -> live run -> result. */
+
+.apo-overlay{
+  position:fixed;
+  inset:0;
+  z-index:120;
+  display:none;
+  align-items:flex-end;
+  justify-content:center;
+  padding:20px;
+  background:rgba(0,0,0,.64);
+  backdrop-filter:blur(8px);
+}
+.apo-overlay.open{display:flex}
+.apo-run-panel{
+  width:min(100%,680px);
+  max-height:min(86vh,820px);
+  overflow:auto;
+  border:1px solid #24313d;
+  border-radius:18px;
+  background:#080d12;
+  box-shadow:0 28px 80px rgba(0,0,0,.48);
+}
+.apo-panel-head{
+  position:sticky;
+  top:0;
+  z-index:2;
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:16px;
+  padding:20px 20px 16px;
+  border-bottom:1px solid #18232d;
+  background:rgba(8,13,18,.96);
+  backdrop-filter:blur(12px);
+}
+.apo-eyebrow{
+  margin-bottom:5px;
+  color:var(--blue-2);
+  font-family:var(--font-nav);
+  font-size:10px;
+  font-weight:600;
+  letter-spacing:.12em;
+  text-transform:uppercase;
+}
+.apo-panel-title{
+  margin:0;
+  font-family:var(--font-display);
+  font-size:24px;
+  font-weight:500;
+  line-height:1.05;
+  letter-spacing:-.035em;
+}
+.apo-close{
+  width:34px;
+  height:34px;
+  flex:0 0 34px;
+  border:1px solid #253441;
+  border-radius:8px;
+  background:#0b1117;
+  color:var(--muted);
+  font-size:20px;
+  cursor:pointer;
+}
+.apo-panel-body{display:grid;gap:22px;padding:20px}
+.apo-section{display:grid;gap:10px}
+.apo-section h3{
+  margin:0;
+  font-family:var(--font-display);
+  font-size:15px;
+  font-weight:500;
+  letter-spacing:-.02em;
+}
+.apo-section-copy{margin:0;color:var(--muted);font-size:12px;line-height:1.5}
+.apo-choice-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}
+.apo-choice{
+  min-height:96px;
+  padding:13px;
+  border:1px solid #1b2834;
+  border-radius:10px;
+  background:#0a1016;
+  color:var(--text);
+  text-align:left;
+  cursor:pointer;
+}
+.apo-choice:hover{border-color:#31465a;background:#0d141b}
+.apo-choice.selected{border-color:var(--blue);background:#0d1723}
+.apo-choice strong{display:block;font-family:var(--font-display);font-size:13px;font-weight:500}
+.apo-choice span{display:block;margin-top:6px;color:var(--muted);font-size:10px;line-height:1.4}
+.apo-choice small{display:block;margin-top:8px;color:var(--blue-2);font-family:var(--font-nav);font-size:9px;letter-spacing:.04em}
+.apo-run-summary{
+  padding:14px 15px;
+  border-left:2px solid var(--blue);
+  background:#0a1118;
+}
+.apo-run-summary strong{display:block;font-family:var(--font-display);font-size:14px;font-weight:500}
+.apo-run-summary span{display:block;margin-top:5px;color:var(--muted);font-size:11px;line-height:1.5}
+.apo-run-primary{
+  min-height:46px;
+  border:0;
+  border-radius:9px;
+  background:var(--blue);
+  color:white;
+  font-family:var(--font-nav);
+  font-size:12px;
+  font-weight:600;
+  letter-spacing:.035em;
+  cursor:pointer;
+}
+.apo-run-primary:disabled{opacity:.45;cursor:wait}
+.apo-progress-line{height:3px;background:#17222c;overflow:hidden}
+.apo-progress-line span{display:block;height:100%;background:var(--blue);width:0;transition:width .25s ease}
+.apo-run-meta{display:flex;flex-wrap:wrap;gap:8px 14px;color:var(--muted);font-family:var(--font-nav);font-size:10px;letter-spacing:.035em}
+.apo-run-meta b{color:var(--text);font-weight:600}
+.apo-stage-list{display:grid;gap:7px}
+.apo-stage{
+  width:100%;
+  padding:12px 13px;
+  border:1px solid #18242e;
+  border-radius:9px;
+  background:#090f14;
+  color:var(--text);
+  text-align:left;
+  cursor:pointer;
+}
+.apo-stage-top{display:grid;grid-template-columns:16px minmax(0,1fr) auto;align-items:center;gap:9px}
+.apo-stage-dot{width:8px;height:8px;border:1px solid #526170;border-radius:50%}
+.apo-stage.running .apo-stage-dot{border-color:var(--blue);background:var(--blue);box-shadow:0 0 0 4px rgba(67,141,255,.1)}
+.apo-stage.completed .apo-stage-dot{border-color:var(--green);background:var(--green)}
+.apo-stage.skipped .apo-stage-dot{border-color:var(--muted-2);background:transparent}
+.apo-stage.failed .apo-stage-dot{border-color:var(--red);background:var(--red)}
+.apo-stage-title{font-family:var(--font-ui);font-size:11px;font-weight:500}
+.apo-stage-state{color:var(--muted);font-family:var(--font-nav);font-size:9px;letter-spacing:.06em;text-transform:uppercase}
+.apo-stage-detail{display:none;margin:9px 0 0 25px;color:var(--muted);font-size:10px;line-height:1.5}
+.apo-stage.expanded .apo-stage-detail{display:block}
+.apo-technical{
+  padding:12px 13px;
+  border:1px solid #17212b;
+  border-radius:9px;
+  background:#070b0f;
+  color:var(--muted);
+  font-family:var(--font-data);
+  font-size:9px;
+  line-height:1.55;
+  white-space:pre-wrap;
+}
+.apo-object-intro{
+  display:grid;
+  gap:10px;
+  margin:0 0 16px;
+  padding:14px 15px;
+  border:1px solid #18242e;
+  border-radius:11px;
+  background:#090f14;
+}
+.apo-object-intro strong{font-family:var(--font-display);font-size:14px;font-weight:500}
+.apo-object-intro p{margin:0;color:var(--muted);font-size:11px;line-height:1.5}
+.apo-object-actions{display:flex;flex-wrap:wrap;gap:7px}
+.apo-object-actions button{
+  min-height:36px;
+  padding:7px 11px;
+  border:1px solid #253441;
+  border-radius:8px;
+  background:#0b1117;
+  color:var(--text);
+  font-family:var(--font-nav);
+  font-size:10px;
+  font-weight:600;
+  cursor:pointer;
+}
+.apo-object-actions button.primary-action{border-color:#255fa9;color:var(--blue-2)}
+.apo-tool-friendly{display:inline-flex;align-items:baseline;gap:5px}
+.apo-tool-friendly small{color:var(--muted-2);font-size:8px}
+#tool-list .chip[data-apotheon-tool]{cursor:pointer}
+.apo-run-peek{
+  position:fixed;
+  z-index:90;
+  left:50%;
+  bottom:calc(92px + env(safe-area-inset-bottom));
+  width:min(calc(100% - 40px),520px);
+  transform:translateX(-50%);
+  display:none;
+  grid-template-columns:minmax(0,1fr) auto;
+  align-items:center;
+  gap:10px;
+  padding:10px 12px;
+  border:1px solid #23313e;
+  border-radius:10px;
+  background:rgba(8,13,18,.96);
+  box-shadow:0 16px 36px rgba(0,0,0,.34);
+  cursor:pointer;
+}
+.apo-run-peek.visible{display:grid}
+.apo-run-peek strong{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:var(--font-ui);font-size:10px;font-weight:500}
+.apo-run-peek span{display:block;margin-top:2px;color:var(--muted);font-size:9px}
+.apo-run-peek b{color:var(--blue-2);font-family:var(--font-data);font-size:10px;font-weight:500}
+
+@media (max-width:640px){
+  .apo-overlay{padding:0;align-items:flex-end}
+  .apo-run-panel{max-height:91vh;border-left:0;border-right:0;border-bottom:0;border-radius:18px 18px 0 0}
+  .apo-choice-grid{grid-template-columns:1fr}
+  .apo-panel-head{padding:18px 18px 14px}
+  .apo-panel-body{padding:18px}
+}

--- a/dashboard/web/orchestrator.js
+++ b/dashboard/web/orchestrator.js
@@ -1,0 +1,494 @@
+(() => {
+  const state = {
+    catalog: null,
+    run: null,
+    selectedTarget: 'lab',
+    selectedProfile: 'standard',
+    pollTimer: null,
+  };
+
+  const targetAliases = {
+    'Main Lab': 'lab',
+    'DVWA': 'dvwa',
+    'Vulnerable Web App': 'dvwa',
+    'Juice Shop': 'juice-shop',
+    'OWASP Juice Shop': 'juice-shop',
+    'WebGoat': 'webgoat',
+    'OWASP WebGoat': 'webgoat',
+  };
+
+  const fallbackCatalog = {
+    targets: {
+      lab: { label: 'Entire Training Lab', short: 'Local Lab', description: 'All intentionally vulnerable web applications in the isolated training lab.', technical: 'Juice Shop, DVWA, and WebGoat' },
+      'juice-shop': { label: 'OWASP Juice Shop', short: 'Juice Shop', description: 'An intentionally vulnerable online store used for safe web security practice.', technical: 'OWASP Juice Shop' },
+      dvwa: { label: 'Vulnerable Web App', short: 'DVWA', description: 'An intentionally vulnerable web application designed for safe security testing.', technical: 'DVWA' },
+      webgoat: { label: 'OWASP WebGoat', short: 'WebGoat', description: 'An intentionally insecure application that teaches common web vulnerabilities.', technical: 'OWASP WebGoat' },
+    },
+    profiles: {
+      quick: { label: 'Quick Check', description: 'Confirm reachability, identify services, and inspect the web response.', technical: 'Nmap plus HTTP inspection' },
+      standard: { label: 'Standard Security Check', description: 'Discover services, inspect the app, and check known vulnerability patterns.', technical: 'Nmap, HTTP inspection, and Nuclei' },
+      deep: { label: 'Deep Security Check', description: 'Run broader service inspection and vulnerability checks.', technical: 'Nmap scripts, service detection, and Nuclei' },
+    },
+    tools: {},
+  };
+
+  function create(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined && text !== null) node.textContent = String(text);
+    return node;
+  }
+
+  function catalog() {
+    return state.catalog || fallbackCatalog;
+  }
+
+  function ensureUI() {
+    let overlay = document.getElementById('apo-run-overlay');
+    if (!overlay) {
+      overlay = create('div', 'apo-overlay');
+      overlay.id = 'apo-run-overlay';
+      overlay.setAttribute('aria-hidden', 'true');
+
+      const panel = create('section', 'apo-run-panel');
+      panel.id = 'apo-run-panel';
+      panel.setAttribute('role', 'dialog');
+      panel.setAttribute('aria-modal', 'true');
+      panel.setAttribute('aria-label', 'APOTHEON automation');
+      overlay.appendChild(panel);
+      document.body.appendChild(overlay);
+
+      overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) closePanel();
+      });
+    }
+
+    let peek = document.getElementById('apo-run-peek');
+    if (!peek) {
+      peek = create('button', 'apo-run-peek');
+      peek.id = 'apo-run-peek';
+      peek.type = 'button';
+      peek.addEventListener('click', () => {
+        if (state.run) renderRun(state.run, true);
+      });
+      document.body.appendChild(peek);
+    }
+    return overlay;
+  }
+
+  function openPanel() {
+    const overlay = ensureUI();
+    overlay.classList.add('open');
+    overlay.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closePanel() {
+    const overlay = document.getElementById('apo-run-overlay');
+    if (!overlay) return;
+    overlay.classList.remove('open');
+    overlay.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+  }
+
+  function panelShell(eyebrow, title) {
+    const panel = document.getElementById('apo-run-panel');
+    panel.replaceChildren();
+
+    const head = create('div', 'apo-panel-head');
+    const heading = create('div');
+    heading.appendChild(create('div', 'apo-eyebrow', eyebrow));
+    heading.appendChild(create('h2', 'apo-panel-title', title));
+    head.appendChild(heading);
+
+    const close = create('button', 'apo-close', '×');
+    close.type = 'button';
+    close.setAttribute('aria-label', 'Close');
+    close.addEventListener('click', closePanel);
+    head.appendChild(close);
+    panel.appendChild(head);
+
+    const body = create('div', 'apo-panel-body');
+    panel.appendChild(body);
+    return body;
+  }
+
+  function section(title, copy) {
+    const node = create('section', 'apo-section');
+    node.appendChild(create('h3', '', title));
+    if (copy) node.appendChild(create('p', 'apo-section-copy', copy));
+    return node;
+  }
+
+  function renderScanBuilder(target) {
+    const data = catalog();
+    if (target && data.targets[target]) state.selectedTarget = target;
+    if (!data.targets[state.selectedTarget]) state.selectedTarget = 'lab';
+    if (!data.profiles[state.selectedProfile]) state.selectedProfile = 'standard';
+
+    openPanel();
+    const body = panelShell('Security automation', 'Run a security check');
+
+    const targetSection = section('1. What do you want to check?', 'Choose the thing APOTHEON should work on. Nothing starts until the target and check are clear.');
+    const targetGrid = create('div', 'apo-choice-grid');
+    Object.entries(data.targets).forEach(([key, row]) => {
+      const button = create('button', `apo-choice${state.selectedTarget === key ? ' selected' : ''}`);
+      button.type = 'button';
+      button.appendChild(create('strong', '', row.label));
+      button.appendChild(create('span', '', row.description));
+      button.appendChild(create('small', '', row.technical));
+      button.addEventListener('click', () => {
+        state.selectedTarget = key;
+        renderScanBuilder();
+      });
+      targetGrid.appendChild(button);
+    });
+    targetSection.appendChild(targetGrid);
+    body.appendChild(targetSection);
+
+    const profileSection = section('2. How thorough should it be?', 'The simple names describe the outcome. Technical details stay available underneath.');
+    const profileGrid = create('div', 'apo-choice-grid');
+    Object.entries(data.profiles).forEach(([key, row]) => {
+      const button = create('button', `apo-choice${state.selectedProfile === key ? ' selected' : ''}`);
+      button.type = 'button';
+      button.appendChild(create('strong', '', row.label));
+      button.appendChild(create('span', '', row.description));
+      button.appendChild(create('small', '', row.technical));
+      button.addEventListener('click', () => {
+        state.selectedProfile = key;
+        renderScanBuilder();
+      });
+      profileGrid.appendChild(button);
+    });
+    profileSection.appendChild(profileGrid);
+    body.appendChild(profileSection);
+
+    const selectedTarget = data.targets[state.selectedTarget];
+    const selectedProfile = data.profiles[state.selectedProfile];
+    const summary = create('div', 'apo-run-summary');
+    summary.appendChild(create('strong', '', `${selectedProfile.label} · ${selectedTarget.label}`));
+    summary.appendChild(create('span', '', `${selectedProfile.description} APOTHEON will show each stage as it happens and keep the technical implementation available on demand.`));
+    body.appendChild(summary);
+
+    const run = create('button', 'apo-run-primary', `Run ${selectedProfile.label}`);
+    run.type = 'button';
+    run.addEventListener('click', () => startScan(run));
+    body.appendChild(run);
+  }
+
+  async function startScan(button) {
+    button.disabled = true;
+    button.textContent = 'Starting…';
+    try {
+      const response = await fetch('/api/action', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ action: 'scan', target: state.selectedTarget, profile: state.selectedProfile }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Unable to start security check');
+      state.run = data.run || null;
+      if (state.run) renderRun(state.run, true);
+      startRunPolling();
+    } catch (error) {
+      button.disabled = false;
+      button.textContent = `Run ${catalog().profiles[state.selectedProfile]?.label || 'check'}`;
+      showInlineError(error instanceof Error ? error.message : 'Unable to start security check');
+    }
+  }
+
+  function showInlineError(message) {
+    const body = document.querySelector('#apo-run-panel .apo-panel-body');
+    if (!body) return;
+    const box = create('div', 'apo-run-summary');
+    box.style.borderLeftColor = 'var(--red)';
+    box.appendChild(create('strong', '', 'Could not start automation'));
+    box.appendChild(create('span', '', message));
+    body.appendChild(box);
+  }
+
+  function runStateLabel(value) {
+    return ({ queued: 'Queued', running: 'Running', succeeded: 'Complete', failed: 'Failed' })[value] || value || 'Unknown';
+  }
+
+  function renderRun(run, open) {
+    state.run = run;
+    ensureUI();
+    updatePeek(run);
+    if (!open && !document.getElementById('apo-run-overlay')?.classList.contains('open')) return;
+
+    openPanel();
+    const body = panelShell(run.state === 'succeeded' ? 'Automation complete' : 'Active run', run.title || 'Running automation');
+
+    const meta = create('div', 'apo-run-meta');
+    const target = create('span');
+    target.append('Target: ');
+    target.appendChild(create('b', '', run.target_label || 'APOTHEON ONE'));
+    meta.appendChild(target);
+    if (run.profile_label) {
+      const profile = create('span');
+      profile.append('Check: ');
+      profile.appendChild(create('b', '', run.profile_label));
+      meta.appendChild(profile);
+    }
+    const status = create('span');
+    status.append('Status: ');
+    status.appendChild(create('b', '', runStateLabel(run.state)));
+    meta.appendChild(status);
+    body.appendChild(meta);
+
+    const progress = create('div', 'apo-progress-line');
+    const progressFill = create('span');
+    progressFill.style.width = `${Number(run.progress || 0)}%`;
+    progress.appendChild(progressFill);
+    body.appendChild(progress);
+
+    if (run.description) {
+      const summary = create('div', 'apo-run-summary');
+      summary.appendChild(create('strong', '', run.state === 'succeeded' ? (run.summary || 'Run complete') : run.description));
+      summary.appendChild(create('span', '', run.technical || 'APOTHEON is tracking this automation as a structured run.'));
+      body.appendChild(summary);
+    }
+
+    const stagesSection = section('What is happening?', 'Tap any stage for a plain explanation of what APOTHEON is doing.');
+    const stages = create('div', 'apo-stage-list');
+    (run.stages || []).forEach((row) => {
+      const button = create('button', `apo-stage ${row.state || 'pending'}`);
+      button.type = 'button';
+      const top = create('div', 'apo-stage-top');
+      top.appendChild(create('span', 'apo-stage-dot'));
+      top.appendChild(create('span', 'apo-stage-title', row.title || row.id));
+      top.appendChild(create('span', 'apo-stage-state', row.state || 'pending'));
+      button.appendChild(top);
+      button.appendChild(create('p', 'apo-stage-detail', row.detail || 'No additional detail available.'));
+      button.addEventListener('click', () => button.classList.toggle('expanded'));
+      stages.appendChild(button);
+    });
+    stagesSection.appendChild(stages);
+    body.appendChild(stagesSection);
+
+    if (Array.isArray(run.technical_tail) && run.technical_tail.length) {
+      const technicalSection = section('Technical details', 'Optional implementation output for people who want to inspect what ran underneath.');
+      technicalSection.appendChild(create('div', 'apo-technical', run.technical_tail.join('\n')));
+      body.appendChild(technicalSection);
+    }
+
+    if (run.state === 'succeeded' || run.state === 'failed') {
+      const next = create('div', 'apo-run-summary');
+      next.appendChild(create('strong', '', run.state === 'succeeded' ? 'What next?' : 'Run needs attention'));
+      next.appendChild(create('span', '', run.state === 'succeeded'
+        ? 'The evidence is saved in run history. Open Activity for the timeline, or run a different check against the same target.'
+        : 'Open Technical details above to see the last execution messages, then adjust the target or check and try again.'));
+      body.appendChild(next);
+    }
+  }
+
+  function updatePeek(run) {
+    const peek = ensureUI().parentElement?.querySelector('#apo-run-peek') || document.getElementById('apo-run-peek');
+    if (!peek || !run) return;
+    peek.replaceChildren();
+    const text = create('div');
+    text.appendChild(create('strong', '', run.title || 'APOTHEON automation'));
+    const current = (run.stages || []).find((stage) => stage.id === run.current_stage);
+    text.appendChild(create('span', '', current?.title || (run.state === 'succeeded' ? 'Completed. Tap to review.' : runStateLabel(run.state))));
+    peek.appendChild(text);
+    peek.appendChild(create('b', '', `${Number(run.progress || 0)}%`));
+    peek.classList.add('visible');
+  }
+
+  async function refreshRun(open) {
+    try {
+      const response = await fetch('/api/run', { cache: 'no-store' });
+      if (!response.ok) return;
+      const data = await response.json();
+      if (!data.run) return;
+      const changed = !state.run || JSON.stringify(state.run) !== JSON.stringify(data.run);
+      state.run = data.run;
+      updatePeek(data.run);
+      if (changed && (open || document.getElementById('apo-run-overlay')?.classList.contains('open'))) renderRun(data.run, open);
+      if (data.run.state === 'running' || data.run.state === 'queued') startRunPolling();
+    } catch (_error) {
+      // Runtime status is supplemental; the main dashboard remains usable if this poll fails.
+    }
+  }
+
+  function startRunPolling() {
+    if (state.pollTimer) return;
+    state.pollTimer = window.setInterval(async () => {
+      await refreshRun(false);
+      if (state.run && !['running', 'queued'].includes(state.run.state)) {
+        window.clearInterval(state.pollTimer);
+        state.pollTimer = null;
+      }
+    }, 1200);
+  }
+
+  function contextTarget() {
+    const title = document.getElementById('detail-title')?.textContent?.trim() || '';
+    return targetAliases[title] || '';
+  }
+
+  function renderInfo(eyebrow, title, description, technical, action) {
+    openPanel();
+    const body = panelShell(eyebrow, title);
+    const info = create('div', 'apo-run-summary');
+    info.appendChild(create('strong', '', 'What is this?'));
+    info.appendChild(create('span', '', description));
+    body.appendChild(info);
+
+    const detail = section('Technical name', 'This is the implementation underneath the plain-language capability.');
+    detail.appendChild(create('div', 'apo-technical', technical));
+    body.appendChild(detail);
+
+    if (action) {
+      const button = create('button', 'apo-run-primary', action.label);
+      button.type = 'button';
+      button.addEventListener('click', action.run);
+      body.appendChild(button);
+    }
+  }
+
+  function targetInfo(key) {
+    const row = catalog().targets[key];
+    if (!row) return;
+    renderInfo('Training target', row.label, row.description, row.technical, {
+      label: 'Run a security check',
+      run: () => renderScanBuilder(key),
+    });
+  }
+
+  function toolInfo(tool) {
+    const row = catalog().tools?.[tool];
+    if (!row) return;
+    renderInfo('Security capability', row.label, row.description, row.technical);
+  }
+
+  function enhanceDetail() {
+    const page = document.getElementById('page-detail');
+    const stage = page?.querySelector('.device-stage');
+    if (!page || !stage) return;
+    const key = contextTarget();
+    const old = page.querySelector('.apo-object-intro');
+    if (!key) {
+      if (old) old.remove();
+      return;
+    }
+    if (old?.dataset.target === key) return;
+    if (old) old.remove();
+
+    const row = catalog().targets[key];
+    if (!row) return;
+    const title = document.getElementById('detail-title');
+    if (title && key === 'dvwa') title.textContent = row.label;
+
+    const box = create('div', 'apo-object-intro');
+    box.dataset.target = key;
+    box.appendChild(create('strong', '', row.label));
+    box.appendChild(create('p', '', row.description));
+    const actions = create('div', 'apo-object-actions');
+    const scan = create('button', 'primary-action', 'Scan this target');
+    scan.type = 'button';
+    scan.addEventListener('click', () => renderScanBuilder(key));
+    actions.appendChild(scan);
+    const explain = create('button', '', 'What is this?');
+    explain.type = 'button';
+    explain.addEventListener('click', () => targetInfo(key));
+    actions.appendChild(explain);
+    box.appendChild(actions);
+    stage.parentNode.insertBefore(box, stage);
+  }
+
+  function enhanceServiceCards() {
+    document.querySelectorAll('.resource-card[data-kind="services"]').forEach((card) => {
+      const key = card.dataset.detailName;
+      const row = catalog().targets[key];
+      if (!row || card.dataset.apotheonExplained === '1') return;
+      card.dataset.apotheonExplained = '1';
+      const title = card.querySelector('.resource-title');
+      if (title && key === 'dvwa') title.textContent = row.label;
+      const meta = card.querySelector('.resource-meta');
+      if (meta) {
+        const description = create('span', 'apo-service-description', row.short || row.technical);
+        description.title = row.description;
+        meta.prepend(description);
+      }
+    });
+  }
+
+  function enhanceTools() {
+    document.querySelectorAll('#tool-list .chip').forEach((chip) => {
+      if (chip.dataset.apotheonTool) return;
+      const tool = chip.textContent.trim();
+      const row = catalog().tools?.[tool];
+      if (!row) return;
+      chip.dataset.apotheonTool = tool;
+      chip.replaceChildren();
+      const friendly = create('span', 'apo-tool-friendly');
+      friendly.appendChild(create('span', '', row.label));
+      friendly.appendChild(create('small', '', row.technical));
+      chip.appendChild(friendly);
+      chip.title = row.description;
+    });
+  }
+
+  function applyEnhancements() {
+    enhanceDetail();
+    enhanceServiceCards();
+    enhanceTools();
+  }
+
+  document.addEventListener('click', (event) => {
+    const target = event.target instanceof Element ? event.target : null;
+    if (!target) return;
+
+    const scanHome = target.closest('#scan-home');
+    if (scanHome) {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      renderScanBuilder();
+      return;
+    }
+
+    const control = target.closest('.control');
+    if (control && /run scan/i.test(control.textContent || '')) {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+      renderScanBuilder(contextTarget());
+      return;
+    }
+
+    const tool = target.closest('#tool-list .chip[data-apotheon-tool]');
+    if (tool) {
+      event.preventDefault();
+      event.stopPropagation();
+      toolInfo(tool.dataset.apotheonTool);
+    }
+  }, true);
+
+  let applyTimer = null;
+  const observer = new MutationObserver(() => {
+    if (applyTimer) return;
+    applyTimer = window.setTimeout(() => {
+      applyTimer = null;
+      applyEnhancements();
+    }, 60);
+  });
+  observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+
+  async function loadCatalog() {
+    try {
+      const response = await fetch('/api/catalog', { cache: 'no-store' });
+      if (response.ok) state.catalog = await response.json();
+    } catch (_error) {
+      state.catalog = fallbackCatalog;
+    }
+    applyEnhancements();
+  }
+
+  ensureUI();
+  loadCatalog();
+  refreshRun(false);
+  window.setInterval(() => refreshRun(false), 7000);
+})();

--- a/security_lab/orchestrator.py
+++ b/security_lab/orchestrator.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404 - fixed argv execution only; shell evaluation is never used.
+import threading
+import time
+from http.server import SimpleHTTPRequestHandler
+from typing import Any
+from urllib.parse import urlparse
+
+from security_lab import dashboard as base
+from security_lab.common import ROOT
+
+
+TARGETS: dict[str, dict[str, Any]] = {
+    "lab": {
+        "label": "Entire Training Lab",
+        "short": "Local Lab",
+        "kind": "training range",
+        "description": "All three intentionally vulnerable web applications running inside the isolated APOTHEON training lab.",
+        "technical": "Juice Shop :3000, DVWA :8080, WebGoat :8081",
+    },
+    "juice-shop": {
+        "label": "OWASP Juice Shop",
+        "short": "Juice Shop",
+        "kind": "training web app",
+        "description": "An intentionally vulnerable online store used to safely practice and demonstrate web application security testing.",
+        "technical": "OWASP Juice Shop on local port 3000",
+        "service": "juice-shop",
+    },
+    "dvwa": {
+        "label": "Vulnerable Web App",
+        "short": "DVWA",
+        "kind": "training web app",
+        "description": "An intentionally vulnerable web application designed for safe, controlled security testing and training.",
+        "technical": "Damn Vulnerable Web Application on local port 8080",
+        "service": "dvwa",
+    },
+    "webgoat": {
+        "label": "OWASP WebGoat",
+        "short": "WebGoat",
+        "kind": "training web app",
+        "description": "An intentionally insecure application that teaches common web vulnerabilities through guided exercises.",
+        "technical": "OWASP WebGoat on local port 8081",
+        "service": "webgoat",
+    },
+}
+
+PROFILES: dict[str, dict[str, Any]] = {
+    "quick": {
+        "label": "Quick Check",
+        "description": "Confirm the target is reachable, identify exposed services, and inspect its web response.",
+        "technical": "Nmap service detection plus HTTP header inspection",
+        "tools": ["nmap", "curl"],
+    },
+    "standard": {
+        "label": "Standard Security Check",
+        "description": "Discover services, inspect the web application, check known vulnerability patterns, and organize the results.",
+        "technical": "Nmap service detection, HTTP inspection, and Nuclei vulnerability templates",
+        "tools": ["nmap", "curl", "nuclei"],
+    },
+    "deep": {
+        "label": "Deep Security Check",
+        "description": "Run broader service inspection and vulnerability checks for a more complete lab assessment.",
+        "technical": "Nmap default scripts and service detection plus Nuclei vulnerability templates",
+        "tools": ["nmap", "curl", "nuclei"],
+    },
+}
+
+TOOLS: dict[str, dict[str, str]] = {
+    "nmap": {"label": "Network Discovery", "description": "Finds reachable network services and identifies what is listening.", "technical": "Nmap"},
+    "nuclei": {"label": "Web Vulnerability Checks", "description": "Checks a web target against known security patterns and misconfigurations.", "technical": "Nuclei"},
+    "httpx": {"label": "Web Service Inspection", "description": "Identifies live web services and collects useful HTTP details.", "technical": "httpx"},
+    "subfinder": {"label": "Subdomain Discovery", "description": "Finds known subdomains that belong to an authorized domain scope.", "technical": "Subfinder"},
+    "naabu": {"label": "Port Discovery", "description": "Quickly identifies network ports that are accepting connections.", "technical": "Naabu"},
+    "semgrep": {"label": "Source Code Analysis", "description": "Reviews source code for risky patterns and security mistakes.", "technical": "Semgrep"},
+    "bandit": {"label": "Python Security Review", "description": "Checks Python source code for common security problems.", "technical": "Bandit"},
+    "pip-audit": {"label": "Dependency Vulnerability Check", "description": "Checks installed Python dependencies for known vulnerabilities.", "technical": "pip-audit"},
+    "trivy": {"label": "Container & Dependency Scan", "description": "Checks containers, packages, and project dependencies for known vulnerabilities.", "technical": "Trivy"},
+    "gitleaks": {"label": "Secret Detection", "description": "Looks for passwords, tokens, keys, and other secrets accidentally stored in source code.", "technical": "Gitleaks"},
+    "ffuf": {"label": "Content Discovery", "description": "Discovers hidden or unlinked web paths within an authorized target.", "technical": "ffuf"},
+    "yara": {"label": "File Pattern Analysis", "description": "Matches files and data against known detection patterns.", "technical": "YARA"},
+    "radare2": {"label": "Binary Analysis", "description": "Inspects compiled programs and firmware at a low level.", "technical": "radare2"},
+    "shellcheck": {"label": "Shell Script Review", "description": "Finds mistakes and unsafe patterns in shell scripts.", "technical": "ShellCheck"},
+}
+
+CATALOG = {
+    "targets": TARGETS,
+    "profiles": PROFILES,
+    "tools": TOOLS,
+    "principle": "Choose a target, choose an outcome, watch the work, understand the result.",
+}
+
+
+def _generic_metadata(name: str) -> dict[str, Any]:
+    rows = (
+        ("range-up", "Starting Training Lab", "Local training lab", "Starts the intentionally vulnerable practice applications."),
+        ("range-down", "Stopping Training Lab", "Local training lab", "Stops the local practice applications."),
+        ("report", "Building Security Report", "Current evidence", "Collects the latest security evidence into a report."),
+        ("review", "Reviewing Source Code", "Repository", "Checks source code for security and quality problems."),
+        ("validate", "Validating Findings", "Current findings", "Re-checks findings to separate confirmed issues from noise."),
+        ("fuzz", "Running Input Testing", "Authorized lab scope", "Exercises application inputs to find unexpected behavior."),
+        ("defend", "Running Defensive Review", "Repository and lab", "Runs the defensive analysis pipeline and organizes findings."),
+        ("kali-start", "Starting Security Workstation", "Kali Operator", "Starts the isolated Kali security workstation."),
+        ("project-init:", "Creating Project", "Development workspace", "Creates a project from the selected starter profile."),
+        ("project-publish:", "Publishing Project", "Private repository", "Publishes the selected project as a private repository."),
+        ("job:", "Running Project Automation", "Development project", "Runs the selected project command and tracks its completion."),
+    )
+    for prefix, title, target, description in rows:
+        if name == prefix or name.startswith(prefix):
+            return {"title": title, "target_label": target, "description": description, "action": name}
+    return {"title": "Running Automation", "target_label": "APOTHEON ONE", "description": "Runs the selected automation and tracks its completion.", "action": name}
+
+
+def _scan_stages(profile: str) -> list[dict[str, str]]:
+    return [
+        {"id": "scope", "title": "Confirm target", "detail": "Lock the run to the selected local training target.", "state": "pending"},
+        {"id": "discover", "title": "Discover services", "detail": "Network Discovery identifies reachable services with Nmap.", "state": "pending"},
+        {"id": "inspect", "title": "Inspect application", "detail": "Read the target web response and collect basic application details.", "state": "pending"},
+        {"id": "weakness", "title": "Check security weaknesses", "detail": "Web Vulnerability Checks use Nuclei when the selected profile includes them.", "state": "pending" if profile != "quick" else "skipped"},
+        {"id": "summarize", "title": "Organize results", "detail": "Save the evidence and make the run available in APOTHEON history.", "state": "pending"},
+    ]
+
+
+class OrchestratorActionManager(base.ActionManager):
+    def __init__(self, log: base.ActivityLog) -> None:
+        super().__init__(log)
+        self._run_lock = threading.Lock()
+        self._run: dict[str, Any] | None = None
+        self._sequence = 0
+
+    def snapshot(self) -> dict[str, Any] | None:
+        with self._run_lock:
+            if self._run is None:
+                return None
+            return json.loads(json.dumps(self._run))
+
+    def submit(self, name: str, argv: tuple[str, ...]) -> bool:
+        metadata = _generic_metadata(name)
+        stages = [{"id": "execute", "title": metadata["title"], "detail": metadata["description"], "state": "pending"}]
+        return self.submit_run(name, argv, metadata, stages)
+
+    def submit_run(
+        self,
+        name: str,
+        argv: tuple[str, ...],
+        metadata: dict[str, Any],
+        stages: list[dict[str, str]],
+    ) -> bool:
+        with self._lock:
+            if self._active is not None:
+                return False
+            self._active = name
+        with self._run_lock:
+            self._sequence += 1
+            run_id = f"run-{int(time.time())}-{self._sequence}"
+            self._run = {
+                "id": run_id,
+                "name": name,
+                "state": "queued",
+                "started_at": int(time.time()),
+                "finished_at": None,
+                "progress": 0,
+                "current_stage": None,
+                "technical_tail": [],
+                "stages": [dict(stage) for stage in stages],
+                **metadata,
+            }
+        threading.Thread(target=self._worker_run, args=(name, argv), daemon=True).start()
+        return True
+
+    def _set_run_state(self, state: str, **updates: Any) -> None:
+        with self._run_lock:
+            if self._run is None:
+                return
+            self._run["state"] = state
+            self._run.update(updates)
+            self._recalculate_progress_locked()
+
+    def _append_technical(self, line: str) -> None:
+        with self._run_lock:
+            if self._run is None:
+                return
+            tail = self._run.setdefault("technical_tail", [])
+            tail.append(line[:500])
+            del tail[:-24]
+
+    def _apply_stage(self, stage_id: str, state: str, title: str, detail: str) -> None:
+        with self._run_lock:
+            if self._run is None:
+                return
+            stages = self._run.get("stages", [])
+            for stage in stages:
+                if stage.get("id") == stage_id:
+                    stage.update({"state": state, "title": title or stage.get("title"), "detail": detail or stage.get("detail")})
+                    break
+            if state == "running":
+                self._run["current_stage"] = stage_id
+            self._recalculate_progress_locked()
+
+    def _recalculate_progress_locked(self) -> None:
+        if self._run is None:
+            return
+        stages = self._run.get("stages", [])
+        if not stages:
+            self._run["progress"] = 0
+            return
+        complete = sum(stage.get("state") in {"completed", "skipped"} for stage in stages)
+        running = any(stage.get("state") == "running" for stage in stages)
+        value = (complete + (0.45 if running else 0.0)) / len(stages) * 100
+        if self._run.get("state") in {"succeeded", "failed"}:
+            value = 100
+        self._run["progress"] = max(0, min(100, round(value)))
+
+    def _worker_run(self, name: str, argv: tuple[str, ...]) -> None:
+        self.log.write(f"ACTION {name}: started")
+        self._set_run_state("running")
+        with self._run_lock:
+            if self._run and self._run.get("stages"):
+                first = self._run["stages"][0]
+                if first.get("state") == "pending":
+                    first["state"] = "running"
+                    self._run["current_stage"] = first.get("id")
+                self._recalculate_progress_locked()
+        returncode = 126
+        try:
+            process = subprocess.Popen(  # nosec B603 - argv is server-constructed and never evaluated by a shell.
+                list(argv),
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            if process.stdout is not None:
+                for raw_line in process.stdout:
+                    line = raw_line.rstrip()
+                    if not line:
+                        continue
+                    if line.startswith("APOTHEON_STAGE|"):
+                        parts = line.split("|", 4)
+                        if len(parts) == 5:
+                            _, stage_id, state, title, detail = parts
+                            self._apply_stage(stage_id, state, title, detail)
+                            continue
+                    self._append_technical(line)
+                    self.log.write(f"{name}: {line}")
+            returncode = process.wait()
+            self.log.write(f"ACTION {name}: finished rc={returncode}")
+        except OSError as exc:
+            self._append_technical(str(exc))
+            self.log.write(f"ACTION {name}: failed: {exc}")
+        finally:
+            final_state = "succeeded" if returncode == 0 else "failed"
+            with self._run_lock:
+                if self._run is not None:
+                    for stage in self._run.get("stages", []):
+                        if stage.get("state") == "running":
+                            stage["state"] = "completed" if returncode == 0 else "failed"
+                        elif stage.get("state") == "pending" and returncode == 0:
+                            stage["state"] = "completed"
+                    self._run["state"] = final_state
+                    self._run["finished_at"] = int(time.time())
+                    self._run["current_stage"] = None
+                    self._run["summary"] = "Automation completed successfully." if returncode == 0 else f"Automation stopped with exit code {returncode}."
+                    self._recalculate_progress_locked()
+            with self._lock:
+                self._active = None
+
+
+class OrchestratorDashboardState(base.DashboardState):
+    def payload(self) -> dict[str, Any]:
+        payload = super().payload()
+        payload["orchestrator"] = CATALOG
+        payload["run"] = self.actions.snapshot() if isinstance(self.actions, OrchestratorActionManager) else None
+        services = payload.get("services", {})
+        for key, target in TARGETS.items():
+            if key in services:
+                services[key]["description"] = target["description"]
+                services[key]["technical"] = target["technical"]
+                services[key]["friendly_label"] = target["label"]
+        return payload
+
+
+class OrchestratorHandler(base.Handler):
+    actions: OrchestratorActionManager
+
+    def end_headers(self) -> None:
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("Cross-Origin-Resource-Policy", "same-origin")
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()")
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+            "font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline'; "
+            "connect-src 'self'; img-src 'self' data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+        )
+        SimpleHTTPRequestHandler.end_headers(self)
+
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path
+        if path == "/api/catalog":
+            self.send_json(CATALOG)
+            return
+        if path == "/api/run":
+            self.send_json({"run": self.actions.snapshot()})
+            return
+        super().do_GET()
+
+    def _security_action(self, payload: dict[str, Any]) -> None:
+        requested = payload.get("action")
+        if requested != "scan":
+            super()._security_action(payload)
+            return
+
+        target = str(payload.get("target") or "lab").strip().lower()
+        profile = str(payload.get("profile") or "standard").strip().lower()
+        if target not in TARGETS:
+            self.send_json({"error": "unsupported scan target"}, 400)
+            return
+        if profile not in PROFILES:
+            self.send_json({"error": "unsupported scan profile"}, 400)
+            return
+
+        target_row = TARGETS[target]
+        profile_row = PROFILES[profile]
+        label = f"scan:{target}:{profile}"
+        argv = ("bash", str(ROOT / "bin" / "labscan"), target, profile)
+        metadata = {
+            "action": "scan",
+            "title": f"Scanning {target_row['label']}",
+            "target": target,
+            "target_label": target_row["label"],
+            "profile": profile,
+            "profile_label": profile_row["label"],
+            "description": profile_row["description"],
+            "technical": profile_row["technical"],
+            "tools": profile_row["tools"],
+        }
+        if not self.actions.submit_run(label, argv, metadata, _scan_stages(profile)):
+            self.send_json({"error": "another action is already running", "active": self.actions.active}, 409)
+            return
+        self.send_json({"ok": True, "action": "scan", "target": target, "profile": profile, "run": self.actions.snapshot()}, 202)
+
+
+def main() -> int:
+    base.ActionManager = OrchestratorActionManager
+    base.DashboardState = OrchestratorDashboardState
+    base.Handler = OrchestratorHandler
+    return base.main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements Stage 1 of issue #354 for the client-demo path.

What changes:
- Add a structured orchestration runtime layered over the existing dashboard server
- Keep scan targets restricted to the local training lab: Entire Lab, Juice Shop, DVWA, WebGoat
- Add Quick, Standard, and Deep scan profiles with fixed server-side argv
- Make `bin/labscan` target-aware and emit structured stage markers
- Add `/api/catalog` and `/api/run` for plain-language capabilities and current/last run state
- Add an interactive Active Run window with progress, discrete stages, expandable explanations, and optional technical output
- Intercept Run Scan so the user always selects or inherits a clear target and scan depth before execution
- Add context-aware “Scan this target” and “What is this?” actions on lab service detail pages
- Turn tool inventory entries into plain-language capabilities while retaining technical tool names
- Permit the explicitly selected Google-hosted web fonts in dashboard CSP so the typography layer can actually render as designed

Existing project actions, security allowlisting, backend APIs, and controller behavior are preserved outside the new orchestration layer. Scan input remains enum-restricted and cannot become an arbitrary target or command.

Closes the demo-critical Stage 1 portion of #354.