### PR TITLE
Wire dashboard control to orchestration runtime

### DIFF
--- a/bin/dashboard-control
+++ b/bin/dashboard-control
@@ -18,7 +18,7 @@ is_running() {
   pid="$(read_pid)"
   [ -n "$pid" ] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
-  tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | grep -q 'security_lab.dashboard'
+  tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | grep -Eq 'security_lab\.(orchestrator|dashboard)'
 }
 
 health_check() {
@@ -80,7 +80,7 @@ start_console() {
 
   rm -f "$PIDFILE"
   cd "$ROOT"
-  nohup python3 -m security_lab.dashboard >>"$LOGFILE" 2>&1 </dev/null &
+  nohup python3 -m security_lab.orchestrator >>"$LOGFILE" 2>&1 </dev/null &
   local pid=$!
   printf '%s\n' "$pid" > "$PIDFILE"
 


### PR DESCRIPTION
Follow-up to #355. The orchestration server was added correctly, but `bin/dashboard-control` still launched the legacy `security_lab.dashboard` module directly. This changes the runtime launcher to `security_lab.orchestrator` and accepts either legacy or orchestration process names during transition. Without this change, a normal dashboard restart would not expose the new target-aware scan flow or Active Run API.