### PR TITLE
Fix verified Codespace refresh repository sync

### DIFF
--- a/.github/workflows/refresh-codespace-safe.yml
+++ b/.github/workflows/refresh-codespace-safe.yml
@@ -94,11 +94,32 @@ jobs:
             gh codespace ssh -c "$name" -- "$@"
           }
 
-          remote bash -lc 'cd /workspaces/Security-Lab && bash bin/dashboard-control restart'
+          repo_dir="$(remote bash -lc 'for d in /workspaces/*; do if [ -d "$d/.git" ]; then printf "%s\n" "$d"; break; fi; done' | tr -d '\r')"
+          if [ -z "$repo_dir" ]; then
+            printf '%s\n' 'Fresh Codespace is reachable over SSH but no checked-out repository was found under /workspaces.' >&2
+            exit 7
+          fi
+
+          remote bash -lc "cd '$repo_dir' && git fetch origin master && git switch master && git merge --ff-only origin/master"
+
+          dashboard_ready='false'
+          for _ in $(seq 1 60); do
+            if remote bash -lc "cd '$repo_dir' && test -f bin/dashboard-control" >/dev/null 2>&1; then
+              dashboard_ready='true'
+              break
+            fi
+            sleep 2
+          done
+          if [ "$dashboard_ready" != 'true' ]; then
+            printf 'Repository %s is present but bin/dashboard-control did not become available.\n' "$repo_dir" >&2
+            exit 8
+          fi
+
+          remote bash -lc "cd '$repo_dir' && bash bin/dashboard-control restart"
           remote bash -lc 'curl -fsS --max-time 8 http://127.0.0.1:8765/health >/dev/null'
           remote bash -lc 'curl -fsS --max-time 8 http://127.0.0.1:8765/api/catalog >/dev/null'
           remote bash -lc 'curl -fsS --max-time 8 http://127.0.0.1:8765/api/run >/dev/null'
-          sha="$(remote bash -lc 'cd /workspaces/Security-Lab && git rev-parse HEAD' | tr -d '\r')"
+          sha="$(remote bash -lc "cd '$repo_dir' && git rev-parse HEAD" | tr -d '\r')"
 
           printf 'codespace=%s\n' "$name" >> "$GITHUB_OUTPUT"
           printf 'predecessor=%s\n' "$predecessor" >> "$GITHUB_OUTPUT"
@@ -136,7 +157,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --repo "$REPOSITORY" --body 'Verified performance refresh failed. No predecessor Codespace is deleted by this workflow. Check the workflow log for the exact provisioning, SSH, or health-check failure.' || true
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPOSITORY" --body 'Verified performance refresh failed. No predecessor Codespace is deleted by this workflow. Check the workflow log for the exact provisioning, SSH, repository-sync, or health-check failure.' || true
 
       - name: Close request
         if: always()


### PR DESCRIPTION
The first verified performance refresh reached a new Codespace over SSH, but verification failed because the workflow assumed the checkout was immediately ready at a fixed path. This makes the refresh discover the checked-out repository under /workspaces, fast-forward it to current master, wait for bin/dashboard-control, then restart and verify /health, /api/catalog, and /api/run. The predecessor remains preserved and no Codespace deletion is added.