### PR TITLE
Condense home layout and add persistent theme switch

### DIFF
--- a/dashboard/web/app.js
+++ b/dashboard/web/app.js
@@ -1,7 +1,85 @@
 (() => {
+  const THEME_KEY = "apotheon-theme";
+  const storedTheme = localStorage.getItem(THEME_KEY);
+  let activeTheme = storedTheme === "light" ? "light" : "dark";
+
+  const applyTheme = (theme) => {
+    activeTheme = theme === "light" ? "light" : "dark";
+    document.documentElement.dataset.theme = activeTheme;
+    document.documentElement.style.colorScheme = activeTheme;
+    localStorage.setItem(THEME_KEY, activeTheme);
+
+    const themeColor = document.querySelector('meta[name="theme-color"]');
+    if (themeColor) themeColor.content = activeTheme === "dark" ? "#05070a" : "#f4f6f8";
+
+    document.querySelectorAll("[data-theme-toggle]").forEach((button) => {
+      const dark = activeTheme === "dark";
+      button.classList.toggle("on", dark);
+      button.setAttribute("aria-pressed", String(dark));
+      button.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
+      const icon = button.querySelector("[data-theme-icon]");
+      const label = button.querySelector("[data-theme-label]");
+      if (icon) icon.textContent = dark ? "☾" : "☀";
+      if (label) label.textContent = dark ? "Dark" : "Light";
+    });
+  };
+
+  document.documentElement.dataset.theme = activeTheme;
+
   const homeTitle = document.querySelector("#page-home .brand-title");
-  if (homeTitle) homeTitle.textContent = "Unified. Elevated.";
+  if (homeTitle) homeTitle.textContent = "APOTHEON ONE";
+  const homeKicker = document.querySelector("#page-home .brand-kicker");
+  if (homeKicker) homeKicker.innerHTML = '<span class="brand-dot"></span>Unified. Elevated.';
   document.title = "APOTHEON ONE · Unified. Elevated.";
+
+  const homeGrid = document.getElementById("home-grid");
+  const quickStrip = document.querySelector("#page-home .quick-strip");
+  const quickHead = quickStrip?.previousElementSibling;
+  if (homeGrid && quickStrip && quickHead?.classList.contains("section-head")) {
+    quickHead.style.marginTop = "12px";
+    homeGrid.parentNode.insertBefore(quickHead, homeGrid);
+    homeGrid.parentNode.insertBefore(quickStrip, homeGrid);
+  }
+
+  const scanLabel = document.querySelector("#scan-home span");
+  if (scanLabel) scanLabel.textContent = "Security check";
+
+  const platformStatus = document.getElementById("platform-status");
+  if (platformStatus && !document.querySelector("#page-home .topbar-actions")) {
+    const actions = document.createElement("div");
+    actions.className = "topbar-actions";
+    platformStatus.parentNode.insertBefore(actions, platformStatus);
+
+    const themeButton = document.createElement("button");
+    themeButton.type = "button";
+    themeButton.className = "theme-switch";
+    themeButton.dataset.themeToggle = "true";
+    themeButton.innerHTML = '<span data-theme-icon aria-hidden="true">☾</span><span data-theme-label>Dark</span>';
+    actions.appendChild(themeButton);
+    actions.appendChild(platformStatus);
+  }
+
+  const appearanceLabel = Array.from(document.querySelectorAll("#page-settings .setting b"))
+    .find((node) => node.textContent.trim() === "Appearance");
+  const appearanceSetting = appearanceLabel?.closest(".setting");
+  if (appearanceSetting) {
+    appearanceLabel.textContent = "Dark mode";
+    const description = appearanceSetting.querySelector("small");
+    if (description) description.textContent = "Switch between dark and light interface themes.";
+    const oldValue = appearanceSetting.querySelector(".setting-value");
+    const themeToggle = document.createElement("button");
+    themeToggle.type = "button";
+    themeToggle.className = "toggle theme-setting-toggle";
+    themeToggle.dataset.themeToggle = "true";
+    themeToggle.setAttribute("aria-label", "Toggle dark mode");
+    if (oldValue) oldValue.replaceWith(themeToggle);
+    else appearanceSetting.appendChild(themeToggle);
+  }
+
+  document.querySelectorAll("[data-theme-toggle]").forEach((button) => {
+    button.addEventListener("click", () => applyTheme(activeTheme === "dark" ? "light" : "dark"));
+  });
+  applyTheme(activeTheme);
 
   const brandStyles = document.createElement("link");
   brandStyles.rel = "stylesheet";

--- a/dashboard/web/ux-polish.css
+++ b/dashboard/web/ux-polish.css
@@ -36,8 +36,9 @@ body{
 }
 
 #page-home .brand-title{
-  font-weight:500;
-  letter-spacing:-.047em;
+  font-weight:600;
+  letter-spacing:-.05em;
+  font-size:clamp(2.35rem,9vw,4.4rem);
 }
 
 #page-systems .brand-title,
@@ -177,4 +178,276 @@ pre,
   font-family:var(--font-nav);
   font-weight:600;
   letter-spacing:.03em;
+}
+
+/* Home hierarchy: identity first, compact actions immediately below. */
+#page-home .topbar{
+  align-items:flex-start;
+  gap:18px;
+  padding-bottom:12px;
+}
+
+#page-home .brand-kicker{
+  margin-bottom:7px;
+  font-size:10px;
+  letter-spacing:.14em;
+}
+
+#page-home .brand-sub{
+  max-width:42rem;
+  margin-top:8px;
+}
+
+.topbar-actions{
+  display:flex;
+  align-items:center;
+  justify-content:flex-end;
+  gap:12px;
+  flex:0 0 auto;
+}
+
+.theme-switch{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:7px;
+  min-height:34px;
+  padding:6px 9px;
+  border:1px solid var(--line);
+  border-radius:8px;
+  background:var(--surface);
+  color:var(--muted);
+  font-family:var(--font-nav);
+  font-size:10px;
+  font-weight:600;
+  letter-spacing:.05em;
+  cursor:pointer;
+}
+
+.theme-switch:hover{
+  color:var(--text);
+  border-color:#344456;
+}
+
+.theme-switch [data-theme-icon]{
+  font-family:var(--font-ui);
+  font-size:14px;
+  line-height:1;
+}
+
+#page-home .section-head{
+  margin-bottom:8px;
+}
+
+#page-home .section-head h2{
+  font-size:1.05rem;
+  letter-spacing:-.018em;
+}
+
+#page-home .section-head p{
+  display:none;
+}
+
+.quick-strip{
+  display:grid;
+  grid-template-columns:repeat(4,minmax(0,1fr));
+  gap:8px;
+  margin-bottom:18px;
+}
+
+.quick-action{
+  min-height:48px!important;
+  padding:8px 10px!important;
+  display:flex!important;
+  flex-direction:row!important;
+  align-items:center!important;
+  justify-content:flex-start!important;
+  gap:8px!important;
+  text-align:left!important;
+  border-radius:8px!important;
+}
+
+.quick-action .qa-icon{
+  width:24px!important;
+  height:24px!important;
+  flex:0 0 24px;
+}
+
+.quick-action .qa-icon::before{
+  width:18px!important;
+  height:18px!important;
+}
+
+.quick-action span{
+  font-size:10px!important;
+  line-height:1.1;
+  letter-spacing:.04em;
+  white-space:normal;
+}
+
+#home-grid{
+  margin-top:2px;
+}
+
+.hero-grid{
+  gap:10px!important;
+}
+
+.hero-card{
+  min-height:0!important;
+  padding:16px!important;
+}
+
+.hero-card .hero-top{
+  margin-bottom:14px!important;
+}
+
+.hero-card .hero-metric{
+  font-size:clamp(1.7rem,5vw,2.4rem)!important;
+}
+
+.hero-card .hero-foot{
+  margin-top:14px!important;
+}
+
+.theme-setting-toggle{
+  flex:0 0 auto;
+}
+
+/* Light theme. The dark theme remains the default. */
+html[data-theme="light"]{
+  color-scheme:light;
+  --bg:#f4f6f8;
+  --surface:#ffffff;
+  --surface-2:#f8fafc;
+  --surface-3:#edf2f6;
+  --line:#d4dde6;
+  --line-soft:#e4e9ef;
+  --text:#111820;
+  --muted:#596675;
+  --muted-2:#758291;
+}
+
+html[data-theme="light"] body{
+  background:#f4f6f8;
+  color:var(--text);
+}
+
+html[data-theme="light"] .rail,
+html[data-theme="light"] .bottom-nav{
+  background:#ffffff!important;
+  border-color:#d8e0e8!important;
+}
+
+html[data-theme="light"] .rail-button.active,
+html[data-theme="light"] .hero-card,
+html[data-theme="light"] .panel,
+html[data-theme="light"] .resource-card,
+html[data-theme="light"] .system-card,
+html[data-theme="light"] .health-card,
+html[data-theme="light"] .summary,
+html[data-theme="light"] .settings-list,
+html[data-theme="light"] .quick-action,
+html[data-theme="light"] .control,
+html[data-theme="light"] .theme-switch,
+html[data-theme="light"] .sheet{
+  background:#ffffff!important;
+  border-color:#d8e0e8!important;
+  color:var(--text)!important;
+}
+
+html[data-theme="light"] .hero-card:hover,
+html[data-theme="light"] .resource-card:hover,
+html[data-theme="light"] .quick-action:hover,
+html[data-theme="light"] .control:hover{
+  background:#f8fafc!important;
+  border-color:#c1ccd7!important;
+}
+
+html[data-theme="light"] .segmented{
+  border-color:#d6dee6!important;
+}
+
+html[data-theme="light"] .nav-button{
+  color:#657383!important;
+}
+
+html[data-theme="light"] .nav-button.active,
+html[data-theme="light"] .segment.active{
+  color:#145fc4!important;
+}
+
+html[data-theme="light"] .terminal,
+html[data-theme="light"] code,
+html[data-theme="light"] pre{
+  background:#f2f5f8!important;
+  color:#23303d!important;
+}
+
+html[data-theme="light"] input,
+html[data-theme="light"] select,
+html[data-theme="light"] textarea,
+html[data-theme="light"] .form-row input,
+html[data-theme="light"] .form-row select{
+  background:#ffffff!important;
+  color:#111820!important;
+  border-color:#ccd6df!important;
+}
+
+html[data-theme="light"] .sheet-backdrop{
+  background:rgba(22,30,38,.24)!important;
+}
+
+html[data-theme="light"] .brand-sub,
+html[data-theme="light"] .section-head p,
+html[data-theme="light"] .resource-meta,
+html[data-theme="light"] .setting small,
+html[data-theme="light"] .system-card small{
+  color:#647181!important;
+}
+
+@media (max-width:760px){
+  #page-home .topbar{
+    padding-top:10px;
+    padding-bottom:10px;
+  }
+
+  #page-home .brand-title{
+    font-size:clamp(2.25rem,12vw,3.45rem);
+  }
+
+  .topbar-actions{
+    gap:8px;
+  }
+
+  .theme-switch{
+    min-width:34px;
+    width:34px;
+    padding:6px;
+  }
+
+  .theme-switch [data-theme-label]{
+    display:none;
+  }
+
+  .quick-strip{
+    grid-template-columns:repeat(2,minmax(0,1fr));
+    gap:7px;
+    margin-bottom:14px;
+  }
+
+  .quick-action{
+    min-height:44px!important;
+    padding:7px 9px!important;
+  }
+
+  .hero-card{
+    padding:14px!important;
+  }
+}
+
+@media (min-width:900px){
+  .quick-strip{
+    max-width:760px;
+  }
 }


### PR DESCRIPTION
Implements the latest APOTHEON ONE layout pass without changing orchestration or project execution logic.

- makes APOTHEON ONE the dominant home title and moves Unified. Elevated. into the supporting identity line
- moves Quick Actions directly beneath the header
- compresses the four primary actions into a tight responsive control grid
- reduces home-card spacing and padding
- adds a persistent light/dark theme switch in the home header and Settings
- preserves the selected theme in localStorage
- keeps dark mode as the default