### PR TITLE
Harden unattended runtime maintenance and deployment recovery

### DIFF
--- a/.github/workflows/deploy-codespace.yml
+++ b/.github/workflows/deploy-codespace.yml
@@ -91,11 +91,7 @@ jobs:
           deployed_sha="$(remote "cd $repo_q && git rev-parse HEAD" | tr -d '\r')"
 
           verify_runtime() {
-            remote "cd $repo_q && bash bin/dashboard-control restart" &&
-            remote 'curl -fsS --max-time 5 http://127.0.0.1:8765/health >/dev/null' &&
-            remote 'curl -fsS --max-time 5 http://127.0.0.1:8765/api/catalog >/dev/null' &&
-            remote 'curl -fsS --max-time 5 http://127.0.0.1:8765/api/run >/dev/null' &&
-            remote 'status="$(curl -fsS --max-time 8 http://127.0.0.1:8765/api/status)"; printf "%s" "$status" | jq -e ".platform.runners.github_actions.safe == true" >/dev/null; printf "Cloud automation connected via %s; scopes=%s\n" "$(printf "%s" "$status" | jq -r ".platform.runners.github_actions.credential_source // \"unknown\"")" "$(printf "%s" "$status" | jq -r ".platform.runners.github_actions.scopes // [] | join(\",\")")"'
+            remote "cd $repo_q && bash bin/dashboard-control restart && bash bin/runtime-smoke"
           }
 
           if ! verify_runtime; then

--- a/.github/workflows/deploy-codespace.yml
+++ b/.github/workflows/deploy-codespace.yml
@@ -9,7 +9,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: apotheon-one-inplace-deploy-${{ github.repository }}
+  group: apotheon-one-codespace-mutation-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:
@@ -86,12 +86,29 @@ jobs:
             exit 7
           fi
 
+          previous_sha="$(remote "cd $repo_q && git rev-parse HEAD" | tr -d '\r')"
           remote "cd $repo_q && git fetch origin master && git switch master && git merge --ff-only origin/master"
-          remote "cd $repo_q && bash bin/dashboard-control restart"
-          remote 'curl -fsS --max-time 5 http://127.0.0.1:8765/health >/dev/null'
-          remote 'curl -fsS --max-time 5 http://127.0.0.1:8765/api/catalog >/dev/null'
-          remote 'curl -fsS --max-time 5 http://127.0.0.1:8765/api/run >/dev/null'
-          remote 'status="$(curl -fsS --max-time 8 http://127.0.0.1:8765/api/status)"; printf "%s" "$status" | jq -e ".platform.runners.github_actions.safe == true" >/dev/null; printf "Cloud automation connected via %s; scopes=%s\n" "$(printf "%s" "$status" | jq -r ".platform.runners.github_actions.credential_source // \"unknown\"")" "$(printf "%s" "$status" | jq -r ".platform.runners.github_actions.scopes // [] | join(\",\")")"'
+          deployed_sha="$(remote "cd $repo_q && git rev-parse HEAD" | tr -d '\r')"
+
+          verify_runtime() {
+            remote "cd $repo_q && bash bin/dashboard-control restart" &&
+            remote 'curl -fsS --max-time 5 http://127.0.0.1:8765/health >/dev/null' &&
+            remote 'curl -fsS --max-time 5 http://127.0.0.1:8765/api/catalog >/dev/null' &&
+            remote 'curl -fsS --max-time 5 http://127.0.0.1:8765/api/run >/dev/null' &&
+            remote 'status="$(curl -fsS --max-time 8 http://127.0.0.1:8765/api/status)"; printf "%s" "$status" | jq -e ".platform.runners.github_actions.safe == true" >/dev/null; printf "Cloud automation connected via %s; scopes=%s\n" "$(printf "%s" "$status" | jq -r ".platform.runners.github_actions.credential_source // \"unknown\"")" "$(printf "%s" "$status" | jq -r ".platform.runners.github_actions.scopes // [] | join(\",\")")"'
+          }
+
+          if ! verify_runtime; then
+            printf 'Runtime verification failed after deploying %s. Restoring %s.\n' "$deployed_sha" "$previous_sha" >&2
+            remote "cd $repo_q && git reset --hard $previous_sha"
+            if remote "cd $repo_q && bash bin/dashboard-control restart" && \
+               remote 'curl -fsS --max-time 5 http://127.0.0.1:8765/health >/dev/null'; then
+              printf 'Previous runtime %s restored successfully.\n' "$previous_sha" >&2
+            else
+              printf 'Rollback to %s was attempted but the previous runtime did not pass health verification.\n' "$previous_sha" >&2
+            fi
+            exit 10
+          fi
 
           ports="$(gh codespace ports -c "$name" --json browseUrl,sourcePort,visibility)"
           console="$(printf '%s' "$ports" | jq -r '[.[] | select((.sourcePort | tonumber?) == 8765)] | .[0].browseUrl // empty')"
@@ -137,11 +154,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --repo "$REPOSITORY" --body "APOTHEON:ONE in-place deployment failed. The workflow now requires internal runtime health, working Cloud automation authorization, and a usable response from the browser-facing Codespaces gateway before it reports a console link. It also stops for dirty/unpushed work, SSH failures, or repository discovery failures. No replacement Codespace was created by this workflow."
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPOSITORY" --body "APOTHEON:ONE in-place deployment failed. The workflow requires internal runtime health, working Cloud automation authorization, and a usable Codespaces gateway response. It stops for dirty/unpushed work or repository discovery failures. If internal runtime verification fails after advancing the code, it now attempts to restore the previously running commit and re-check health. No replacement Codespace is created or deleted by this workflow."
 
-      - name: Close request
-        if: always()
+      - name: Close successful request
+        if: success()
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh issue close "$ISSUE_NUMBER" --repo "$REPOSITORY" --reason completed || true
+
+      - name: Close failed request
+        if: failure()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh issue close "$ISSUE_NUMBER" --repo "$REPOSITORY" --reason 'not planned' || gh issue close "$ISSUE_NUMBER" --repo "$REPOSITORY" || true

--- a/.github/workflows/maintenance-codespace.yml
+++ b/.github/workflows/maintenance-codespace.yml
@@ -1,0 +1,153 @@
+name: APOTHEON ONE Safe Maintenance
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: apotheon-one-codespace-mutation-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  maintenance:
+    if: >-
+      github.event.issue.user.login == github.repository_owner &&
+      github.event.issue.title == '[DPSR-MAINTENANCE] safe Codespace'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      CODESPACES_TOKEN: ${{ secrets.DPSR_CODESPACES_TOKEN }}
+      REPOSITORY: ${{ github.repository }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      ISSUE_BODY: ${{ github.event.issue.body }}
+      GH_TOKEN: ${{ secrets.DPSR_CODESPACES_TOKEN }}
+    steps:
+      - name: Run non-destructive maintenance
+        id: maintenance
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          if [ -z "${CODESPACES_TOKEN:-}" ]; then
+            printf '%s\n' 'DPSR_CODESPACES_TOKEN is not configured.' >&2
+            exit 2
+          fi
+
+          requested="$(printf '%s\n' "${ISSUE_BODY:-}" | sed -nE 's/^codespace:[[:space:]]*([A-Za-z0-9][A-Za-z0-9-]{0,127})[[:space:]]*$/\1/p' | head -n 1)"
+          payload="$(gh api '/user/codespaces?per_page=100')"
+          if [ -n "$requested" ]; then
+            name="$(printf '%s' "$payload" | jq -r --arg repo "$REPOSITORY" --arg name "$requested" '[.codespaces[] | select(.repository.full_name == $repo and .name == $name)] | .[0].name // empty')"
+          else
+            name="$(printf '%s' "$payload" | jq -r --arg repo "$REPOSITORY" '[.codespaces[] | select(.repository.full_name == $repo)] | sort_by(.last_used_at // .updated_at // .created_at) | reverse | .[0].name // empty')"
+          fi
+          if [ -z "$name" ]; then
+            printf '%s\n' 'No matching Codespace was found.' >&2
+            exit 3
+          fi
+
+          state="$(gh api "/user/codespaces/${name}" --jq '.state // "Unknown"')"
+          if [ "$state" = 'Shutdown' ]; then
+            gh api -X POST "/user/codespaces/${name}/start" >/dev/null
+            for _ in $(seq 1 120); do
+              state="$(gh api "/user/codespaces/${name}" --jq '.state // "Unknown"')"
+              [ "$state" = 'Available' ] && break
+              sleep 2
+            done
+          fi
+          if [ "$state" != 'Available' ]; then
+            printf 'Codespace %s is not available; state=%s.\n' "$name" "$state" >&2
+            exit 4
+          fi
+
+          remote() {
+            gh codespace ssh -c "$name" -- "$1"
+          }
+
+          repo_dir="$(remote "find /workspaces -mindepth 2 -maxdepth 2 -type d -name .git -print -quit | sed 's#/.git\$##'" | tr -d '\r')"
+          if [ -z "$repo_dir" ]; then
+            printf '%s\n' 'Codespace is reachable over SSH but no checked-out repository was found under /workspaces.' >&2
+            exit 5
+          fi
+          printf -v repo_q '%q' "$repo_dir"
+
+          dirty="$(remote "cd $repo_q && git status --porcelain=v1")"
+          if [ -n "$dirty" ]; then
+            printf '%s\n' 'Codespace has uncommitted changes. Maintenance stopped without modifying the working tree or caches.' >&2
+            printf '%s\n' "$dirty" >&2
+            exit 6
+          fi
+
+          unpushed="$(remote "cd $repo_q && git rev-list @{upstream}..HEAD 2>/dev/null || true")"
+          if [ -n "$unpushed" ]; then
+            printf '%s\n' 'Codespace has unpushed commits. Maintenance stopped without modifying the working tree or caches.' >&2
+            exit 7
+          fi
+
+          head_sha="$(remote "cd $repo_q && git rev-parse HEAD" | tr -d '\r')"
+          before="$(remote "df -h / | awk 'NR==2 {printf \"%s used / %s free (%s)\", \$3, \$4, \$5}'" | tr -d '\r')"
+
+          remote "cd $repo_q && bash bin/doctor"
+          remote "cd $repo_q && bash -n bin/dashboard-control bin/disk-guard bin/doctor bin/runtime-smoke"
+          remote "cd $repo_q && python3 -m compileall -q security_lab"
+          remote "cd $repo_q && docker compose -f lab/docker-compose.yml config >/dev/null"
+
+          pytest_result='not available'
+          if remote "cd $repo_q && python3 -c 'import pytest' >/dev/null 2>&1"; then
+            if remote "cd $repo_q && timeout 420 python3 -m pytest -q"; then
+              pytest_result='passed'
+            else
+              pytest_result='failed'
+            fi
+          fi
+
+          remote "cd $repo_q && bash bin/disk-guard"
+          after="$(remote "df -h / | awk 'NR==2 {printf \"%s used / %s free (%s)\", \$3, \$4, \$5}'" | tr -d '\r')"
+
+          smoke_result='passed'
+          if ! remote "cd $repo_q && bash bin/runtime-smoke"; then
+            smoke_result='failed'
+          fi
+
+          printf 'codespace=%s\n' "$name" >> "$GITHUB_OUTPUT"
+          printf 'sha=%s\n' "$head_sha" >> "$GITHUB_OUTPUT"
+          printf 'before=%s\n' "$before" >> "$GITHUB_OUTPUT"
+          printf 'after=%s\n' "$after" >> "$GITHUB_OUTPUT"
+          printf 'pytest=%s\n' "$pytest_result" >> "$GITHUB_OUTPUT"
+          printf 'smoke=%s\n' "$smoke_result" >> "$GITHUB_OUTPUT"
+
+          if [ "$pytest_result" = 'failed' ] || [ "$smoke_result" = 'failed' ]; then
+            exit 11
+          fi
+
+      - name: Report maintenance
+        if: success()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPOSITORY" --body "APOTHEON:ONE safe maintenance completed. Repository, Python, shell, Compose, runtime, and Cloud automation checks passed. Existing disk-guard cleanup ran only according to its usage threshold and only targets disposable caches/build data.\n\nCodespace: \`${{ steps.maintenance.outputs.codespace }}\`\nCommit: \`${{ steps.maintenance.outputs.sha }}\`\nDisk before: ${{ steps.maintenance.outputs.before }}\nDisk after: ${{ steps.maintenance.outputs.after }}\nRuntime pytest: \`${{ steps.maintenance.outputs.pytest }}\`\nRuntime smoke test: \`${{ steps.maintenance.outputs.smoke }}\`\n\nNo Codespace was created, deleted, or replaced, and repository history was not rewritten."
+
+      - name: Report maintenance failure
+        if: failure()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPOSITORY" --body "APOTHEON:ONE safe maintenance stopped because a guard or verification failed. The workflow refuses dirty/unpushed repositories and never creates, deletes, or replaces a Codespace. Review the Actions run before making any corrective change."
+
+      - name: Close successful request
+        if: success()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh issue close "$ISSUE_NUMBER" --repo "$REPOSITORY" --reason completed || true
+
+      - name: Close failed request
+        if: failure()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh issue close "$ISSUE_NUMBER" --repo "$REPOSITORY" --reason 'not planned' || gh issue close "$ISSUE_NUMBER" --repo "$REPOSITORY" || true

--- a/bin/dashboard-control
+++ b/bin/dashboard-control
@@ -6,6 +6,8 @@ PIDFILE="$ROOT/.dashboard.pid"
 DISABLED="$ROOT/.dashboard.disabled"
 LOGFILE="$ROOT/reports/dashboard.log"
 PORT=8765
+LOG_MAX_BYTES="${DASHBOARD_LOG_MAX_BYTES:-5242880}"
+LOG_KEEP_BYTES="${DASHBOARD_LOG_KEEP_BYTES:-2097152}"
 
 read_pid() {
   if [ -f "$PIDFILE" ]; then
@@ -47,6 +49,26 @@ console_url() {
   fi
 }
 
+trim_log() {
+  [ -f "$LOGFILE" ] || return 0
+  local size tmp
+  size="$(wc -c < "$LOGFILE" 2>/dev/null || printf '0')"
+  case "$size" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  if [ "$size" -le "$LOG_MAX_BYTES" ]; then
+    return 0
+  fi
+
+  tmp="${LOGFILE}.trim.$$"
+  if tail -c "$LOG_KEEP_BYTES" "$LOGFILE" > "$tmp" 2>/dev/null; then
+    mv "$tmp" "$LOGFILE"
+    printf 'APOTHEON:ONE dashboard log trimmed from %s to approximately %s bytes.\n' "$size" "$LOG_KEEP_BYTES"
+  else
+    rm -f "$tmp"
+  fi
+}
+
 stop_process() {
   if ! is_running; then
     rm -f "$PIDFILE"
@@ -70,7 +92,7 @@ start_console() {
   mkdir -p "$ROOT/reports"
   rm -f "$DISABLED"
   if healthy; then
-    printf 'APOTHEON ONE console already running: pid=%s\n' "$(read_pid)"
+    printf 'APOTHEON:ONE console already running: pid=%s\n' "$(read_pid)"
     printf 'URL: %s\n' "$(console_url)"
     return 0
   fi
@@ -78,6 +100,7 @@ start_console() {
     stop_process
   fi
 
+  trim_log
   rm -f "$PIDFILE"
   cd "$ROOT"
   nohup python3 -m security_lab.orchestrator >>"$LOGFILE" 2>&1 </dev/null &
@@ -87,40 +110,40 @@ start_console() {
   for _ in $(seq 1 30); do
     if ! kill -0 "$pid" 2>/dev/null; then
       rm -f "$PIDFILE"
-      printf 'APOTHEON ONE console failed to start.\n' >&2
+      printf 'APOTHEON:ONE console failed to start.\n' >&2
       tail -n 40 "$LOGFILE" >&2 || true
       return 1
     fi
     if health_check; then
-      printf 'APOTHEON ONE console running: pid=%s\n' "$pid"
+      printf 'APOTHEON:ONE console running: pid=%s\n' "$pid"
       printf 'URL: %s\n' "$(console_url)"
       return 0
     fi
     sleep 0.5
   done
 
-  printf 'APOTHEON ONE console process is running but health endpoint is not ready.\n' >&2
+  printf 'APOTHEON:ONE console process is running but health endpoint is not ready.\n' >&2
   return 1
 }
 
 stop_console() {
   touch "$DISABLED"
   stop_process
-  printf 'APOTHEON ONE console stopped.\n'
+  printf 'APOTHEON:ONE console stopped.\n'
 }
 
 status_console() {
   if healthy; then
-    printf 'APOTHEON ONE console running: pid=%s\n' "$(read_pid)"
+    printf 'APOTHEON:ONE console running: pid=%s\n' "$(read_pid)"
     printf 'URL: %s\n' "$(console_url)"
     return 0
   fi
   if is_running; then
-    printf 'APOTHEON ONE console unhealthy: pid=%s health check failed.\n' "$(read_pid)" >&2
+    printf 'APOTHEON:ONE console unhealthy: pid=%s health check failed.\n' "$(read_pid)" >&2
     return 1
   fi
   rm -f "$PIDFILE"
-  printf 'APOTHEON ONE console stopped.\n'
+  printf 'APOTHEON:ONE console stopped.\n'
   return 1
 }
 

--- a/bin/runtime-smoke
+++ b/bin/runtime-smoke
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${APOTHEON_PORT:-8765}"
+BASE="http://127.0.0.1:${PORT}"
+
+bash "$ROOT/bin/dashboard-control" status >/dev/null
+curl -fsS --max-time 5 "$BASE/health" >/dev/null
+curl -fsS --max-time 5 "$BASE/api/catalog" >/dev/null
+curl -fsS --max-time 5 "$BASE/api/run" >/dev/null
+
+status="$(curl -fsS --max-time 8 "$BASE/api/status")"
+printf '%s' "$status" | jq -e '.platform.runners.github_actions.safe == true' >/dev/null
+
+source_name="$(printf '%s' "$status" | jq -r '.platform.runners.github_actions.credential_source // "unknown"')"
+scopes="$(printf '%s' "$status" | jq -r '.platform.runners.github_actions.scopes // [] | join(",")')"
+printf 'APOTHEON:ONE runtime healthy. Cloud automation=%s; scopes=%s\n' "$source_name" "$scopes"

--- a/tests/test_identity_contract.py
+++ b/tests/test_identity_contract.py
@@ -18,6 +18,10 @@ PUBLIC_SURFACES = (
     ROOT / "bin" / "repair-tools",
     ROOT / "bin" / "update-all",
 )
+ACCEPTED_APOTHEON_IDENTITIES = (
+    "APOTHEON:ONE",
+    "APOTHEON ONE",
+)
 FORBIDDEN_PUBLIC_IDENTITIES = (
     "Digital Paragon Security Research",
     "DPSR Platform",
@@ -64,7 +68,10 @@ class IdentityContractTests(unittest.TestCase):
         for path in PUBLIC_SURFACES:
             with self.subTest(path=path.relative_to(ROOT)):
                 text = path.read_text(encoding="utf-8")
-                self.assertIn("APOTHEON ONE", text)
+                self.assertTrue(
+                    any(identity in text for identity in ACCEPTED_APOTHEON_IDENTITIES),
+                    f"APOTHEON identity missing from {path.relative_to(ROOT)}",
+                )
 
     def test_retired_product_names_do_not_reappear_in_source(self) -> None:
         violations: list[str] = []


### PR DESCRIPTION
Maintenance-window reliability pass with non-destructive boundaries.

Changes:
- bounds dashboard log growth to avoid silent disk consumption
- adds a reusable read-only runtime smoke test for dashboard endpoints and Cloud automation authorization
- changes in-place deploys to share a Codespace mutation concurrency lock
- automatically restores the previously running commit if the newly deployed runtime fails internal verification
- adds an owner-only safe maintenance workflow that refuses dirty/unpushed work, runs diagnostics, shell/Python/Compose checks, optional runtime pytest, threshold-gated disk cleanup through the existing disk-guard, and a final runtime smoke test
- never creates, deletes, or replaces a Codespace

Merge only after CI and CodeQL pass.