### PR TITLE
Preserve Codespaces runtime credentials during in-place deploy

### DIFF
--- a/.github/workflows/deploy-codespace.yml
+++ b/.github/workflows/deploy-codespace.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
           remote() {
-            gh codespace ssh -c "$name" -- "$1"
+            gh codespace ssh -c "$name" -- bash -lc "$1"
           }
 
           repo_dir="$(remote "find /workspaces -mindepth 2 -maxdepth 2 -type d -name .git -print -quit | sed 's#/.git\$##'" | tr -d '\r')"


### PR DESCRIPTION
The failed in-place deploy on issue #402 passed dashboard, health, catalog, and run checks, then failed Cloud automation authorization for all 15 retries. The rollback restored the previous healthy commit successfully.

This changes the remote execution helper in the in-place deploy workflow to run commands through a login shell (`bash -lc`), matching the existing repair path that loads the Codespace runtime environment before restarting APOTHEON:ONE. No Codespace lifecycle behavior changes, and rollback remains intact.

Merge only after CI and CodeQL are green.