### PR TITLE
Stream Codespace login-shell commands over stdin

### DIFF
--- a/.github/workflows/deploy-codespace.yml
+++ b/.github/workflows/deploy-codespace.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
           remote() {
-            gh codespace ssh -c "$name" -- bash -lc "$1"
+            printf '%s\n' "$1" | gh codespace ssh -c "$name" -- bash -l -s
           }
 
           repo_dir="$(remote "find /workspaces -mindepth 2 -maxdepth 2 -type d -name .git -print -quit | sed 's#/.git\$##'" | tr -d '\r')"


### PR DESCRIPTION
Issue #405 failed before touching the Codespace with `/usr/bin/gh: Argument list too long` while invoking the login-shell SSH helper. This keeps login-shell semantics but streams each short maintenance command to `bash -l -s` over stdin instead of passing it as an SSH command argument. The existing dirty/unpushed guards and rollback behavior are unchanged.

Merge only after CI and CodeQL are green.