### PR TITLE
Prevent irrelevant issue workflows from cancelling deploys

### DIFF
--- a/.github/workflows/deploy-codespace.yml
+++ b/.github/workflows/deploy-codespace.yml
@@ -9,7 +9,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: apotheon-one-codespace-mutation-${{ github.repository }}
+  group: apotheon-one-inplace-deploy-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Issue #407 never reached the Codespace. The deploy workflow run was cancelled immediately while other issue-triggered lifecycle workflows were also starting/skipping under the same workflow-level concurrency group. GitHub keeps only one pending run per concurrency group, so unrelated skipped issue workflows can evict the actual deploy.

This restores a deploy-specific workflow concurrency group. The maintenance automation still refuses to open a second lifecycle request while another is active, and the deploy retains dirty/unpushed guards plus rollback protection.

Merge only after CI and CodeQL are green.