### PR TITLE
Preserve dashboard runner credentials across restarts

### DIFF
--- a/bin/dashboard-control
+++ b/bin/dashboard-control
@@ -8,6 +8,8 @@ LOGFILE="$ROOT/reports/dashboard.log"
 PORT=8765
 LOG_MAX_BYTES="${DASHBOARD_LOG_MAX_BYTES:-5242880}"
 LOG_KEEP_BYTES="${DASHBOARD_LOG_KEEP_BYTES:-2097152}"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/apotheon-one"
+RUNTIME_ENV_FILE="$STATE_DIR/dashboard-runtime.env"
 
 read_pid() {
   if [ -f "$PIDFILE" ]; then
@@ -69,6 +71,60 @@ trim_log() {
   fi
 }
 
+capture_runtime_env() {
+  is_running || return 0
+  local pid
+  pid="$(read_pid)"
+  mkdir -p "$STATE_DIR"
+  chmod 700 "$STATE_DIR"
+  python3 - "$pid" "$RUNTIME_ENV_FILE" <<'PY'
+import os
+import shlex
+import sys
+from pathlib import Path
+
+pid, destination = sys.argv[1], Path(sys.argv[2])
+allowed = {
+    "DPSR_BRIDGE_TOKEN",
+    "DPSR_RUNNER_GITHUB_TOKEN",
+    "DPSR_RUNNER_GH_CONFIG",
+    "DPSR_RUNNER_GIT_CONFIG",
+}
+try:
+    entries = Path(f"/proc/{pid}/environ").read_bytes().split(b"\0")
+except OSError:
+    raise SystemExit(0)
+
+captured = {}
+for entry in entries:
+    if b"=" not in entry:
+        continue
+    key_raw, value_raw = entry.split(b"=", 1)
+    key = key_raw.decode("utf-8", "ignore")
+    if key not in allowed:
+        continue
+    value = value_raw.decode("utf-8", "surrogateescape")
+    if value:
+        captured[key] = value
+
+if not captured:
+    raise SystemExit(0)
+
+temporary = destination.with_name(destination.name + f".tmp.{os.getpid()}")
+with temporary.open("w", encoding="utf-8") as handle:
+    for key in sorted(captured):
+        handle.write(f"export {key}={shlex.quote(captured[key])}\n")
+os.chmod(temporary, 0o600)
+os.replace(temporary, destination)
+PY
+}
+
+restore_runtime_env() {
+  [ -f "$RUNTIME_ENV_FILE" ] || return 0
+  # shellcheck source=/dev/null
+  . "$RUNTIME_ENV_FILE"
+}
+
 stop_process() {
   if ! is_running; then
     rm -f "$PIDFILE"
@@ -97,10 +153,12 @@ start_console() {
     return 0
   fi
   if is_running; then
+    capture_runtime_env
     stop_process
   fi
 
   trim_log
+  restore_runtime_env
   rm -f "$PIDFILE"
   cd "$ROOT"
   nohup python3 -m security_lab.orchestrator >>"$LOGFILE" 2>&1 </dev/null &
@@ -150,7 +208,7 @@ status_console() {
 case "${1:-status}" in
   start) start_console ;;
   stop) stop_console ;;
-  restart) stop_process; start_console ;;
+  restart) capture_runtime_env; stop_process; start_console ;;
   status) status_console ;;
   *)
     printf 'Usage: %s {start|stop|restart|status}\n' "$0" >&2


### PR DESCRIPTION
Fix the verified in-place deployment failure where runtime endpoints passed but Cloud automation authorization disappeared after restarting APOTHEON:ONE.

This change snapshots only the dashboard process's APOTHEON GitHub credential/config environment variables into a private state file outside the repository before a restart, then restores them for the replacement process. It does not log credential values, modify Codespace lifecycle state, rewrite repository history, or bypass existing runtime smoke checks.

Merge only after CI and CodeQL pass.