### PR TITLE
Preserve login-shell runner auth during dashboard restart

### DIFF
--- a/bin/dashboard-control
+++ b/bin/dashboard-control
@@ -72,9 +72,10 @@ trim_log() {
 }
 
 capture_runtime_env() {
-  is_running || return 0
-  local pid
-  pid="$(read_pid)"
+  local pid=""
+  if is_running; then
+    pid="$(read_pid)"
+  fi
   mkdir -p "$STATE_DIR"
   chmod 700 "$STATE_DIR"
   python3 - "$pid" "$RUNTIME_ENV_FILE" <<'PY'
@@ -90,22 +91,28 @@ allowed = {
     "DPSR_RUNNER_GH_CONFIG",
     "DPSR_RUNNER_GIT_CONFIG",
 }
-try:
-    entries = Path(f"/proc/{pid}/environ").read_bytes().split(b"\0")
-except OSError:
-    raise SystemExit(0)
 
-captured = {}
-for entry in entries:
-    if b"=" not in entry:
-        continue
-    key_raw, value_raw = entry.split(b"=", 1)
-    key = key_raw.decode("utf-8", "ignore")
-    if key not in allowed:
-        continue
-    value = value_raw.decode("utf-8", "surrogateescape")
-    if value:
-        captured[key] = value
+captured = {
+    key: value
+    for key in allowed
+    if (value := os.environ.get(key, ""))
+}
+
+if pid:
+    try:
+        entries = Path(f"/proc/{pid}/environ").read_bytes().split(b"\0")
+    except OSError:
+        entries = []
+    for entry in entries:
+        if b"=" not in entry:
+            continue
+        key_raw, value_raw = entry.split(b"=", 1)
+        key = key_raw.decode("utf-8", "ignore")
+        if key not in allowed:
+            continue
+        value = value_raw.decode("utf-8", "surrogateescape")
+        if value:
+            captured[key] = value
 
 if not captured:
     raise SystemExit(0)

--- a/bin/runtime-smoke
+++ b/bin/runtime-smoke
@@ -36,17 +36,32 @@ STATUS_PAYLOAD=""
 check_cloud() {
   local payload
   payload="$(curl -fsS --max-time 8 "$BASE/api/status")" || return 1
-  if ! printf '%s' "$payload" | jq -e '.platform.runners.github_actions.safe == true' >/dev/null; then
-    return 1
-  fi
   STATUS_PAYLOAD="$payload"
+  printf '%s' "$payload" | jq -e '.platform.runners.github_actions.safe == true' >/dev/null
+}
+
+cloud_diagnostic() {
+  local payload="$STATUS_PAYLOAD"
+  if [ -z "$payload" ]; then
+    payload="$(curl -fsS --max-time 8 "$BASE/api/status" 2>/dev/null || true)"
+  fi
+  [ -n "$payload" ] || return 0
+  printf 'Cloud auth diagnostic: source=%s authenticated=%s missing=%s unexpected=%s scopes=%s\n' \
+    "$(printf '%s' "$payload" | jq -r '.platform.runners.github_actions.credential_source // "unknown"')" \
+    "$(printf '%s' "$payload" | jq -r '.platform.runners.github_actions.authenticated // false')" \
+    "$(printf '%s' "$payload" | jq -r '.platform.runners.github_actions.missing_scopes // [] | join(",")')" \
+    "$(printf '%s' "$payload" | jq -r '.platform.runners.github_actions.unexpected_scopes // [] | join(",")')" \
+    "$(printf '%s' "$payload" | jq -r '.platform.runners.github_actions.scopes // [] | join(",")')" >&2
 }
 
 retry 'dashboard process and health' check_dashboard
 retry 'health endpoint' check_endpoint "$BASE/health"
 retry 'catalog endpoint' check_endpoint "$BASE/api/catalog"
 retry 'run endpoint' check_endpoint "$BASE/api/run"
-retry 'Cloud automation authorization' check_cloud
+if ! retry 'Cloud automation authorization' check_cloud; then
+  cloud_diagnostic
+  exit 1
+fi
 
 source_name="$(printf '%s' "$STATUS_PAYLOAD" | jq -r '.platform.runners.github_actions.credential_source // "unknown"')"
 scopes="$(printf '%s' "$STATUS_PAYLOAD" | jq -r '.platform.runners.github_actions.scopes // [] | join(",")')"


### PR DESCRIPTION
Issue #411 verified that the new runtime passed dashboard, health, catalog, and run checks, then failed Cloud automation authorization and rolled back successfully.

This follow-up keeps the restart reversible and fixes the remaining credential handoff gap:
- capture allowed runner credential/config variables from the maintenance login shell as a fallback, while still preferring the currently running dashboard process values when present
- keep the private state file outside the repository with 0600 permissions
- add redacted Cloud auth diagnostics to runtime-smoke failures so future failures report source/auth/scopes without exposing credentials
- no Codespace lifecycle changes, no history rewriting, and rollback behavior remains unchanged

Merge only after CI and CodeQL are green.