### PR TITLE
Prefer verified isolated runner auth over under-scoped bridge token

### DIFF
--- a/bin/dashboard-control
+++ b/bin/dashboard-control
@@ -132,6 +132,29 @@ restore_runtime_env() {
   . "$RUNTIME_ENV_FILE"
 }
 
+prefer_isolated_runner_auth() {
+  if [ -n "${DPSR_RUNNER_GITHUB_TOKEN:-}" ]; then
+    return 0
+  fi
+
+  local config
+  config="${DPSR_RUNNER_GH_CONFIG:-}"
+  if [ -z "$config" ]; then
+    config="$(cd "$ROOT" && python3 - <<'PY'
+from security_lab.platform.github_actions import RUNNER_GH_CONFIG
+print(RUNNER_GH_CONFIG)
+PY
+)"
+  fi
+
+  if [ -n "$config" ] && [ -d "$config" ] && \
+     env -u GH_TOKEN -u GITHUB_TOKEN -u DPSR_BRIDGE_TOKEN \
+       GH_CONFIG_DIR="$config" GH_PROMPT_DISABLED=1 \
+       gh auth status --hostname github.com >/dev/null 2>&1; then
+    unset DPSR_BRIDGE_TOKEN
+  fi
+}
+
 stop_process() {
   if ! is_running; then
     rm -f "$PIDFILE"
@@ -166,6 +189,7 @@ start_console() {
 
   trim_log
   restore_runtime_env
+  prefer_isolated_runner_auth
   rm -f "$PIDFILE"
   cd "$ROOT"
   nohup python3 -m security_lab.orchestrator >>"$LOGFILE" 2>&1 </dev/null &


### PR DESCRIPTION
Issue #413 gave the exact failure: the Codespaces bridge credential is authenticated but lacks the required `workflow` scope (`codespace,gist,read:org,repo`). Historical deploy #395 succeeded through the existing isolated GitHub config.

This change keeps credential precedence safe:
- dedicated `DPSR_RUNNER_GITHUB_TOKEN` still wins when present
- otherwise, if the isolated runner config is actually authenticated, the dashboard drops the under-scoped bridge token for that process so the isolated config can be used
- if isolated config is absent or invalid, the bridge token remains as fallback
- no credential values are logged
- no Codespace lifecycle behavior changes and deploy rollback remains intact

Merge only after CI and CodeQL are green.