### PR TITLE
Always run built-in unit tests during safe maintenance

### DIFF
--- a/.github/workflows/maintenance-codespace.yml
+++ b/.github/workflows/maintenance-codespace.yml
@@ -91,16 +91,12 @@ jobs:
 
           remote "cd $repo_q && bash bin/doctor"
           remote "cd $repo_q && bash -n bin/dashboard-control bin/disk-guard bin/doctor bin/runtime-smoke"
-          remote "cd $repo_q && python3 -m compileall -q security_lab"
+          remote "cd $repo_q && python3 -m compileall -q security_lab tests"
           remote "cd $repo_q && docker compose -f lab/docker-compose.yml config >/dev/null"
 
-          pytest_result='not available'
-          if remote "cd $repo_q && python3 -c 'import pytest' >/dev/null 2>&1"; then
-            if remote "cd $repo_q && timeout 420 python3 -m pytest -q"; then
-              pytest_result='passed'
-            else
-              pytest_result='failed'
-            fi
+          unit_test_result='passed'
+          if ! remote "cd $repo_q && timeout 420 python3 -m unittest discover -s tests -v"; then
+            unit_test_result='failed'
           fi
 
           remote "cd $repo_q && bash bin/disk-guard"
@@ -115,10 +111,10 @@ jobs:
           printf 'sha=%s\n' "$head_sha" >> "$GITHUB_OUTPUT"
           printf 'before=%s\n' "$before" >> "$GITHUB_OUTPUT"
           printf 'after=%s\n' "$after" >> "$GITHUB_OUTPUT"
-          printf 'pytest=%s\n' "$pytest_result" >> "$GITHUB_OUTPUT"
+          printf 'unit_tests=%s\n' "$unit_test_result" >> "$GITHUB_OUTPUT"
           printf 'smoke=%s\n' "$smoke_result" >> "$GITHUB_OUTPUT"
 
-          if [ "$pytest_result" = 'failed' ] || [ "$smoke_result" = 'failed' ]; then
+          if [ "$unit_test_result" = 'failed' ] || [ "$smoke_result" = 'failed' ]; then
             exit 11
           fi
 
@@ -128,7 +124,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue comment "$ISSUE_NUMBER" --repo "$REPOSITORY" --body "APOTHEON:ONE safe maintenance completed. Repository, Python, shell, Compose, runtime, and Cloud automation checks passed. Existing disk-guard cleanup ran only according to its usage threshold and only targets disposable caches/build data.\n\nCodespace: \`${{ steps.maintenance.outputs.codespace }}\`\nCommit: \`${{ steps.maintenance.outputs.sha }}\`\nDisk before: ${{ steps.maintenance.outputs.before }}\nDisk after: ${{ steps.maintenance.outputs.after }}\nRuntime pytest: \`${{ steps.maintenance.outputs.pytest }}\`\nRuntime smoke test: \`${{ steps.maintenance.outputs.smoke }}\`\n\nNo Codespace was created, deleted, or replaced, and repository history was not rewritten."
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPOSITORY" --body "APOTHEON:ONE safe maintenance completed. Repository, Python, shell, Compose, unit tests, runtime, and Cloud automation checks passed. Existing disk-guard cleanup ran only according to its usage threshold and only targets disposable caches/build data.\n\nCodespace: \`${{ steps.maintenance.outputs.codespace }}\`\nCommit: \`${{ steps.maintenance.outputs.sha }}\`\nDisk before: ${{ steps.maintenance.outputs.before }}\nDisk after: ${{ steps.maintenance.outputs.after }}\nUnit tests: \`${{ steps.maintenance.outputs.unit_tests }}\`\nRuntime smoke test: \`${{ steps.maintenance.outputs.smoke }}\`\n\nNo Codespace was created, deleted, or replaced, and repository history was not rewritten."
 
       - name: Report maintenance failure
         if: failure()


### PR DESCRIPTION
The safe maintenance workflow reported runtime pytest as unavailable even though this repository's supported CI test suite uses Python's built-in unittest runner.

This change:
- removes the optional pytest dependency from Codespace maintenance
- always runs `python3 -m unittest discover -s tests -v` with the existing timeout
- compiles both `security_lab` and `tests`
- reports unit-test status directly
- keeps the existing dirty/unpushed guards, threshold-gated disk cleanup, runtime smoke verification, and non-destructive Codespace rules unchanged

Merge only after CI and CodeQL are green.